### PR TITLE
test: Add coverage upload step to GitHub Action workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,12 @@ jobs:
           ./cli-v2 install
       - name: "Run tests"
         run: |
-          go test ./...
+          go test -coverprofile=unit.coverage.out ./...
+      - name: "Upload coverage to Codacy"
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        run: |
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report --force-coverage-parser go -r unit.coverage.out
 
   release:
     needs: test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Build & Test Commands
 - Build: `go build ./cli-v2.go`
 - Run all tests: `go test ./...`
+- Run all tests with coverage: `go test -coverprofile=unit.coverage.out ./...`
 - Run specific test: `go test -run TestName ./package/path`
 - Example: `go test -run TestGetTools ./tools`
 - Format code: `go fmt ./...`


### PR DESCRIPTION
- Activates the coverage option for the test command.
- Submits the coverage report to Codacy (requires a new repository secret that was added manually).