### PR TITLE
fix: Run the action for all branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,4 @@
-on:
-  push:
-    branches: ['*']
+on: push
 
 permissions:
   contents: write


### PR DESCRIPTION
As it was using glob to match, would ignore branches like fix/something