### PR TITLE
breaking: Control the output format with the format flag

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -96,7 +96,7 @@ type Pattern struct {
 func init() {
 	analyzeCmd.Flags().StringVarP(&outputFile, "output", "o", "", "output file for the results")
 	analyzeCmd.Flags().StringVarP(&toolToAnalyze, "tool", "t", "", "Which tool to run analysis with")
-	analyzeCmd.Flags().StringVar(&outputFormat, "format", "", "Output format (use 'sarif' for SARIF format to terminal)")
+	analyzeCmd.Flags().StringVar(&outputFormat, "format", "", "Output format (use 'sarif' for SARIF format)")
 	analyzeCmd.Flags().BoolVarP(&autoFix, "fix", "f", false, "Apply auto fix to your issues when available")
 	analyzeCmd.Flags().BoolVar(&doNewPr, "new-pr", false, "Create a new PR on GitHub containing the fixed issues")
 	rootCmd.AddCommand(analyzeCmd)
@@ -221,10 +221,12 @@ var analyzeCmd = &cobra.Command{
 		nodeBinary := nodeRuntime.Info()["node"]
 
 		log.Printf("Running %s...\n", toolToAnalyze)
+		if outputFormat == "sarif" {
+			log.Println("Output will be in SARIF format")
+		}
+
 		if outputFile != "" {
 			log.Println("Output will be available at", outputFile)
-		} else if outputFormat == "sarif" {
-			log.Println("Output will be in SARIF format")
 		}
 
 		tools.RunEslint(workDirectory, eslintInstallationDirectory, nodeBinary, args, autoFix, outputFile, outputFormat)

--- a/tools/eslintRunner.go
+++ b/tools/eslintRunner.go
@@ -17,12 +17,14 @@ func RunEslint(repositoryToAnalyseDirectory string, eslintInstallationDirectory 
 	if autoFix {
 		cmd.Args = append(cmd.Args, "--fix")
 	}
-	if outputFile != "" {
-		//When writing to file, we write is SARIF
-		cmd.Args = append(cmd.Args, "-f", "@microsoft/eslint-formatter-sarif", "-o", outputFile)
-	} else if outputFormat == "sarif" {
-		//When outputting to terminal in SARIF format
+	if outputFormat == "sarif" {
+		//When outputting in SARIF format
 		cmd.Args = append(cmd.Args, "-f", "@microsoft/eslint-formatter-sarif")
+	}
+
+	if outputFile != "" {
+		//When writing to file, use the output file option
+		cmd.Args = append(cmd.Args, "-o", outputFile)
 	}
 	if len(pathsToCheck) > 0 {
 		cmd.Args = append(cmd.Args, pathsToCheck...)

--- a/tools/eslintRunner_test.go
+++ b/tools/eslintRunner_test.go
@@ -28,7 +28,7 @@ func TestRunEslintToFile(t *testing.T) {
 	eslintInstallationDirectory := filepath.Join(homeDirectory, ".cache/codacy/tools/eslint@9.3.0")
 	nodeBinary := "node"
 
-	RunEslint(repositoryToAnalyze, eslintInstallationDirectory, nodeBinary, nil, false, tempResultFile, "")
+	RunEslint(repositoryToAnalyze, eslintInstallationDirectory, nodeBinary, nil, false, tempResultFile, "sarif")
 
 	expectedSarifBytes, err := os.ReadFile(expectedSarifFile)
 	if err != nil {


### PR DESCRIPTION
Before it would always output to SARIF if it would output to a file