### PR TITLE
Feature/pmd

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -4,4 +4,5 @@ runtimes:
 tools:
     - eslint@9.3.0
     - trivy@0.59.1
+    - pmd@7.12.0
     - pylint@3.3.6

--- a/.cursor/rules/cursor.mdc
+++ b/.cursor/rules/cursor.mdc
@@ -1,0 +1,22 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+
+# Your rule content
+
+## Code Style Guidelines
+- **Imports**: Standard lib first, external packages second, internal last
+- **Naming**: PascalCase for exported (public), camelCase for unexported (private)
+- **Error handling**: Return errors as last value, check with `if err != nil`
+- **Testing**: Use testify/assert package for assertions
+- **Package organization**: Keep related functionality in dedicated packages
+- **Documentation**: Document all exported functions, types, and packages
+- **Commit messages**: Start with verb, be concise and descriptive
+
+## Project Structure
+- `cmd/`: CLI command implementations
+- `config/`: Configuration handling
+- `tools/`: Tool-specific implementations
+- `utils/`: Utility functions

--- a/plugins/tools/pmd/plugin.yaml
+++ b/plugins/tools/pmd/plugin.yaml
@@ -1,0 +1,10 @@
+name: pmd
+description: PMD - An extensible cross-language static code analyzer
+download:
+  url_template: https://github.com/pmd/pmd/releases/download/pmd_releases%2F{{.Version}}/pmd-dist-{{.Version}}-bin.zip
+  file_name_template: pmd-dist-{{.Version}}-bin.zip
+  extension:
+    default: .zip
+binaries:
+  - name: pmd
+    path: pmd-bin-{{.Version}}/bin/pmd

--- a/tools/pmdRunner.go
+++ b/tools/pmdRunner.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"os"
+	"os/exec"
+)
+
+// RunPmd executes PMD static code analyzer with the specified options
+func RunPmd(repositoryToAnalyseDirectory string, pmdBinary string, pathsToCheck []string, outputFile string, outputFormat string, rulesetFile string) error {
+	cmd := exec.Command(pmdBinary, "check")
+
+	// Add ruleset file if provided
+	if rulesetFile != "" {
+		cmd.Args = append(cmd.Args, "--rulesets", rulesetFile)
+	}
+
+	// Add format options
+	if outputFormat == "sarif" {
+		cmd.Args = append(cmd.Args, "--format", "sarif")
+	}
+
+	if outputFile != "" {
+		cmd.Args = append(cmd.Args, "--report-file", outputFile)
+	}
+
+	// Add directory to scan
+	cmd.Args = append(cmd.Args, "--dir", repositoryToAnalyseDirectory)
+
+	cmd.Dir = repositoryToAnalyseDirectory
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
+			// Exit status 4 means violations were found, which is not an error
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/tools/pmdRunner_test.go
+++ b/tools/pmdRunner_test.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunPmdToFile(t *testing.T) {
+	homeDirectory, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Get absolute paths for test files
+	testDirectory := filepath.Join(currentDirectory, "testdata/repositories/pmd")
+	tempResultFile := filepath.Join(os.TempDir(), "pmd.sarif")
+	defer os.Remove(tempResultFile)
+
+	// Use absolute paths for repository and ruleset
+	repositoryToAnalyze := testDirectory
+	rulesetFile := filepath.Join(testDirectory, "pmd-ruleset.xml")
+
+	pmdBinary := filepath.Join(homeDirectory, ".cache/codacy/tools/pmd@7.12.0/pmd-bin-7.12.0/bin/pmd")
+
+	err = RunPmd(repositoryToAnalyze, pmdBinary, nil, tempResultFile, "sarif", rulesetFile)
+	// PMD returns exit status 4 when violations are found, which is expected in our test
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 4 {
+			t.Fatalf("Failed to run PMD: %v", err)
+		}
+	}
+
+	// Check if the output file was created
+	obtainedSarifBytes, err := os.ReadFile(tempResultFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+	obtainedSarif := string(obtainedSarifBytes)
+	filePrefix := "file://" + currentDirectory + "/"
+	fmt.Println(filePrefix)
+	actualSarif := strings.ReplaceAll(obtainedSarif, filePrefix, "")
+	actualSarif = strings.TrimSpace(actualSarif)
+
+	// Read the expected SARIF
+	expectedSarifFile := filepath.Join(testDirectory, "expected.sarif")
+	expectedSarifBytes, err := os.ReadFile(expectedSarifFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	expectedSarif := strings.TrimSpace(string(expectedSarifBytes))
+
+	assert.Equal(t, expectedSarif, actualSarif, "output did not match expected")
+}

--- a/tools/testdata/repositories/pmd/RulesBreaker.java
+++ b/tools/testdata/repositories/pmd/RulesBreaker.java
@@ -1,0 +1,20 @@
+
+/**
+ * This class demonstrates various PMD rule violations.
+ * It is used for testing PMD's rule detection capabilities.
+ * 
+ * @author Codacy Test Team
+ * @version 1.0
+ */
+
+package tools.testdata.repositories.pmd;
+
+/**
+ * A class that demonstrates PMD rule violations.
+ */
+public class RulesBreaker {
+
+    // Breaking naming convention rules
+    private int x;
+
+}

--- a/tools/testdata/repositories/pmd/expected.sarif
+++ b/tools/testdata/repositories/pmd/expected.sarif
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "PMD",
+          "version": "7.12.0",
+          "informationUri": "https://docs.pmd-code.org/latest/",
+          "rules": [
+            {
+              "id": "AtLeastOneConstructor",
+              "shortDescription": {
+                "text": "Each class should declare at least one constructor"
+              },
+              "fullDescription": {
+                "text": "\n\nEach non-static class should declare at least one constructor.\nClasses with solely static members are ignored, refer to [UseUtilityClassRule](pmd_rules_java_design.html#useutilityclass) to detect those.\n\n        "
+              },
+              "helpUri": "https://docs.pmd-code.org/pmd-doc-7.12.0/pmd_rules_java_codestyle.html#atleastoneconstructor",
+              "help": {
+                "text": "\n\nEach non-static class should declare at least one constructor.\nClasses with solely static members are ignored, refer to [UseUtilityClassRule](pmd_rules_java_design.html#useutilityclass) to detect those.\n\n        "
+              },
+              "properties": {
+                "ruleset": "Code Style",
+                "priority": 3,
+                "tags": [
+                  "Code Style"
+                ]
+              }
+            },
+            {
+              "id": "UnusedPrivateField",
+              "shortDescription": {
+                "text": "Avoid unused private fields such as 'x'."
+              },
+              "fullDescription": {
+                "text": "\nDetects when a private field is declared and/or assigned a value, but not used.\n\nSince PMD 6.50.0 private fields are ignored, if the fields are annotated with any annotation or the\nenclosing class has any annotation. Annotations often enable a framework (such as dependency injection, mocking\nor e.g. Lombok) which use the fields by reflection or other means. This usage can't be detected by static code analysis.\nPreviously these frameworks where explicitly allowed by listing their annotations in the property\n\"ignoredAnnotations\", but that turned out to be prone of false positive for any not explicitly considered framework.\n        "
+              },
+              "helpUri": "https://docs.pmd-code.org/pmd-doc-7.12.0/pmd_rules_java_bestpractices.html#unusedprivatefield",
+              "help": {
+                "text": "\nDetects when a private field is declared and/or assigned a value, but not used.\n\nSince PMD 6.50.0 private fields are ignored, if the fields are annotated with any annotation or the\nenclosing class has any annotation. Annotations often enable a framework (such as dependency injection, mocking\nor e.g. Lombok) which use the fields by reflection or other means. This usage can't be detected by static code analysis.\nPreviously these frameworks where explicitly allowed by listing their annotations in the property\n\"ignoredAnnotations\", but that turned out to be prone of false positive for any not explicitly considered framework.\n        "
+              },
+              "properties": {
+                "ruleset": "Best Practices",
+                "priority": 3,
+                "tags": [
+                  "Best Practices"
+                ]
+              }
+            },
+            {
+              "id": "ShortVariable",
+              "shortDescription": {
+                "text": "Avoid variables with short names like x"
+              },
+              "fullDescription": {
+                "text": "\nFields, local variables, enum constant names or parameter names that are very short are not helpful to the reader.\n        "
+              },
+              "helpUri": "https://docs.pmd-code.org/pmd-doc-7.12.0/pmd_rules_java_codestyle.html#shortvariable",
+              "help": {
+                "text": "\nFields, local variables, enum constant names or parameter names that are very short are not helpful to the reader.\n        "
+              },
+              "properties": {
+                "ruleset": "Code Style",
+                "priority": 3,
+                "tags": [
+                  "Code Style"
+                ]
+              }
+            },
+            {
+              "id": "CommentRequired",
+              "shortDescription": {
+                "text": "Field comments are required"
+              },
+              "fullDescription": {
+                "text": "\nDenotes whether javadoc (formal) comments are required (or unwanted) for specific language elements.\n        "
+              },
+              "helpUri": "https://docs.pmd-code.org/pmd-doc-7.12.0/pmd_rules_java_documentation.html#commentrequired",
+              "help": {
+                "text": "\nDenotes whether javadoc (formal) comments are required (or unwanted) for specific language elements.\n        "
+              },
+              "properties": {
+                "ruleset": "Documentation",
+                "priority": 3,
+                "tags": [
+                  "Documentation"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "AtLeastOneConstructor",
+          "ruleIndex": 0,
+          "message": {
+            "text": "Each class should declare at least one constructor"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "testdata/repositories/pmd/RulesBreaker.java"
+                },
+                "region": {
+                  "startLine": 15,
+                  "startColumn": 8,
+                  "endLine": 15,
+                  "endColumn": 13
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "UnusedPrivateField",
+          "ruleIndex": 1,
+          "message": {
+            "text": "Avoid unused private fields such as 'x'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "testdata/repositories/pmd/RulesBreaker.java"
+                },
+                "region": {
+                  "startLine": 18,
+                  "startColumn": 17,
+                  "endLine": 18,
+                  "endColumn": 18
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ShortVariable",
+          "ruleIndex": 2,
+          "message": {
+            "text": "Avoid variables with short names like x"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "testdata/repositories/pmd/RulesBreaker.java"
+                },
+                "region": {
+                  "startLine": 18,
+                  "startColumn": 17,
+                  "endLine": 18,
+                  "endColumn": 18
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CommentRequired",
+          "ruleIndex": 3,
+          "message": {
+            "text": "Field comments are required"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "testdata/repositories/pmd/RulesBreaker.java"
+                },
+                "region": {
+                  "startLine": 18,
+                  "startColumn": 17,
+                  "endLine": 18,
+                  "endColumn": 18
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": false,
+          "toolConfigurationNotifications": [
+            {
+              "associatedRule": {
+                "id": "LoosePackageCoupling"
+              },
+              "message": {
+                "text": "No packages or classes specified"
+              }
+            }
+          ],
+          "toolExecutionNotifications": []
+        }
+      ]
+    }
+  ]
+}

--- a/tools/testdata/repositories/pmd/pmd-ruleset.xml
+++ b/tools/testdata/repositories/pmd/pmd-ruleset.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="Codacy PMD Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+
+    <description>
+        Basic PMD ruleset for Codacy analysis
+    </description>
+
+    <!-- Import basic rules -->
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="GuardLogStatement"/>
+    </rule>
+    <rule ref="category/java/codestyle.xml"/>
+    <rule ref="category/java/design.xml"/>
+    <rule ref="category/java/documentation.xml"/>
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/multithreading.xml"/>
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/security.xml"/>
+
+</ruleset> 

--- a/utils/download.go
+++ b/utils/download.go
@@ -3,22 +3,29 @@ package utils
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 )
 
 func DownloadFile(url string, destDir string) (string, error) {
+	log.Printf("Attempting to download from URL: %s", url)
+
 	// Get the file name from the URL
 	fileName := filepath.Base(url)
+	log.Printf("Target filename: %s", fileName)
 
 	// Create the destination file path
 	destPath := filepath.Join(destDir, fileName)
+	log.Printf("Destination path: %s", destPath)
 
 	_, errInfo := os.Stat(destPath)
 	if errInfo != nil && os.IsExist(errInfo) {
+		log.Printf("File already exists at destination, skipping download")
 		return destPath, nil
 	}
+
 	// Create the destination file
 	outFile, err := os.Create(destPath)
 	if err != nil {
@@ -27,7 +34,14 @@ func DownloadFile(url string, destDir string) (string, error) {
 	defer outFile.Close()
 
 	// Make the HTTP GET request
-	resp, err := http.Get(url)
+	log.Printf("Making HTTP GET request...")
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Codacy-CLI")
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to make GET request: %w", err)
 	}
@@ -35,13 +49,20 @@ func DownloadFile(url string, destDir string) (string, error) {
 
 	// Check if the request was successful
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to download file: status code %d, URL: %s, Response: %s", resp.StatusCode, url, string(body))
 	}
 
 	// Copy the response body to the destination file
-	_, err = io.Copy(outFile, resp.Body)
+	log.Printf("Downloading file content...")
+	written, err := io.Copy(outFile, resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to copy file contents: %w", err)
+	}
+	log.Printf("Downloaded %d bytes", written)
+
+	if written == 0 {
+		return "", fmt.Errorf("downloaded file is empty (0 bytes)")
 	}
 
 	return destPath, nil


### PR DESCRIPTION
tested locally ✅ 
```
❯ go run cli-v2.go analyze --tool pmd --rulesets ./tools/testdata/repositories/pmd/pmd-ruleset.xml
Running original CLI functionality...
2025/04/01 16:57:53 Running pmd...
[WARN] Progressbar rendering conflicts with reporting to STDOUT. No progressbar will be shown. Try running with argument -r <file> to output the report to a file instead.
[WARN] Removed misconfigured rule: LoosePackageCoupling cause: No packages or classes specified
[WARN] This analysis could be faster, please consider using Incremental Analysis: https://docs.pmd-code.org/pmd-doc-7.12.0/pmd_userdocs_incremental_analysis.html
/Users/czak/GIT/codacy/codacy-cli-v2/tools/testdata/repositories/pmd/RulesBreaker.java:15:      AtLeastOneConstructor:  Each class should declare at least one constructor
/Users/czak/GIT/codacy/codacy-cli-v2/tools/testdata/repositories/pmd/RulesBreaker.java:18:      UnusedPrivateField:     Avoid unused private fields such as 'x'.
/Users/czak/GIT/codacy/codacy-cli-v2/tools/testdata/repositories/pmd/RulesBreaker.java:18:      ShortVariable:  Avoid variables with short names like x
/Users/czak/GIT/codacy/codacy-cli-v2/tools/testdata/repositories/pmd/RulesBreaker.java:18:      CommentRequired:        Field comments are required
LoosePackageCoupling    -       No packages or classes specified
```