### PR TITLE
Create cli configuration file PLUTO-1377

### DIFF
--- a/.codacy/cli-config.yaml
+++ b/.codacy/cli-config.yaml
@@ -1,0 +1,1 @@
+mode: local

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type ConfigType struct {
 	toolsDirectory       string
 	localCodacyDirectory string
 	projectConfigFile    string
+	cliConfigFile        string
 
 	runtimes map[string]*plugins.RuntimeInfo
 	tools    map[string]*plugins.ToolInfo
@@ -43,6 +44,10 @@ func (c *ConfigType) LocalCodacyDirectory() string {
 
 func (c *ConfigType) ProjectConfigFile() string {
 	return c.projectConfigFile
+}
+
+func (c *ConfigType) CliConfigFile() string {
+	return c.cliConfigFile
 }
 
 func (c *ConfigType) Runtimes() map[string]*plugins.RuntimeInfo {
@@ -89,14 +94,8 @@ func (c *ConfigType) setupCodacyPaths() {
 	c.toolsDirectory = filepath.Join(c.globalCacheDirectory, "tools")
 	c.localCodacyDirectory = ".codacy"
 
-	yamlPath := filepath.Join(c.localCodacyDirectory, "codacy.yaml")
-	ymlPath := filepath.Join(c.localCodacyDirectory, "codacy.yml")
-
-	if _, err := os.Stat(ymlPath); err == nil {
-		c.projectConfigFile = ymlPath
-	} else {
-		c.projectConfigFile = yamlPath
-	}
+	c.projectConfigFile = filepath.Join(c.localCodacyDirectory, "codacy.yaml")
+	c.cliConfigFile = filepath.Join(c.localCodacyDirectory, "cli-config.yaml")
 }
 
 func (c *ConfigType) CreateCodacyDirs() error {


### PR DESCRIPTION
Also drops support for codacy.yml, as we control and create that file we pick the extension .yaml for our yaml files.

This PR only adds the file, there are other sub tasks to do the next steps