### PR TITLE
[PLUTO-1396] Handle tool errors gracefully

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -291,7 +291,6 @@ var analyzeCmd = &cobra.Command{
 				log.Printf("Running %s...\n", toolName)
 				if err := runTool(workDirectory, toolName, args, outputFile); err != nil {
 					log.Printf("Tool failed to run: %s: %v\n", toolName, err)
-					continue
 				}
 			}
 		}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -258,7 +258,6 @@ var analyzeCmd = &cobra.Command{
 				tmpFile := filepath.Join(tmpDir, fmt.Sprintf("%s.sarif", toolName))
 				if err := runTool(workDirectory, toolName, args, tmpFile); err != nil {
 					log.Printf("Tool failed to run: %s: %v\n", toolName, err)
-					continue
 				}
 				sarifOutputs = append(sarifOutputs, tmpFile)
 			}

--- a/tools/eslintRunner.go
+++ b/tools/eslintRunner.go
@@ -51,6 +51,10 @@ func RunEslint(repositoryToAnalyseDirectory string, eslintInstallationDirectory 
 	nodePathEnv := "NODE_PATH=" + eslintInstallationNodeModules
 	cmd.Env = append(cmd.Env, nodePathEnv)
 
+	// DEBUG
+	// fmt.Println(cmd.Env)
+	// fmt.Println(cmd)
+
 	// Run the command and handle errors
 	err := cmd.Run()
 	if err != nil {

--- a/tools/eslintRunner.go
+++ b/tools/eslintRunner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"codacy/cli-v2/config"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,7 +11,7 @@ import (
 // * Run from the root of the repo we want to analyse
 // * NODE_PATH="<the installed eslint path>/node_modules"
 // * The local installed ESLint should have the @microsoft/eslint-formatter-sarif installed
-func RunEslint(repositoryToAnalyseDirectory string, eslintInstallationDirectory string, nodeBinary string, pathsToCheck []string, autoFix bool, outputFile string, outputFormat string) {
+func RunEslint(repositoryToAnalyseDirectory string, eslintInstallationDirectory string, nodeBinary string, pathsToCheck []string, autoFix bool, outputFile string, outputFormat string) error {
 	eslintInstallationNodeModules := filepath.Join(eslintInstallationDirectory, "node_modules")
 	eslintJsPath := filepath.Join(eslintInstallationNodeModules, ".bin", "eslint")
 
@@ -50,10 +51,14 @@ func RunEslint(repositoryToAnalyseDirectory string, eslintInstallationDirectory 
 	nodePathEnv := "NODE_PATH=" + eslintInstallationNodeModules
 	cmd.Env = append(cmd.Env, nodePathEnv)
 
-	// DEBUG
-	// fmt.Println(cmd.Env)
-	// fmt.Println(cmd)
-
-	// TODO eslint returns 1 when it finds errors, so we're not propagating it
-	cmd.Run()
+	// Run the command and handle errors
+	err := cmd.Run()
+	if err != nil {
+		// ESLint returns 1 when it finds errors, which is not a failure
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return fmt.Errorf("failed to run ESLint: %w", err)
+	}
+	return nil
 }

--- a/tools/pmdRunner.go
+++ b/tools/pmdRunner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"codacy/cli-v2/config"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -56,7 +57,7 @@ func RunPmd(repositoryToAnalyseDirectory string, pmdBinary string, pathsToCheck 
 			// Exit code 4 means violations found – treat as success
 			return nil
 		}
-		return err
+		return fmt.Errorf("failed to run PMD: %w", err)
 	}
 	return nil
 }

--- a/tools/pylintRunner.go
+++ b/tools/pylintRunner.go
@@ -59,7 +59,7 @@ func RunPylint(workDirectory string, toolInfo *plugins.ToolInfo, files []string,
 		// Pylint returns non-zero exit code when it finds issues
 		// We should not treat this as an error
 		if _, ok := err.(*exec.ExitError); !ok {
-			return fmt.Errorf("failed to run pylint: %w", err)
+			return fmt.Errorf("failed to run Pylint: %w", err)
 		}
 	}
 

--- a/tools/trivyRunner.go
+++ b/tools/trivyRunner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"codacy/cli-v2/config"
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -35,5 +36,9 @@ func RunTrivy(repositoryToAnalyseDirectory string, trivyBinary string, pathsToCh
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
-	return cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run Trivy: %w", err)
+	}
+	return nil
 }

--- a/utils/sarif.go
+++ b/utils/sarif.go
@@ -261,7 +261,11 @@ func createEmptySarifReport() []byte {
 			},
 		},
 	}
-	sarifData, _ := json.MarshalIndent(emptyReport, "", "  ")
+	sarifData, err := json.MarshalIndent(emptyReport, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling empty SARIF report: %v\n", err)
+		return []byte("{}")
+	}
 	return sarifData
 }
 
@@ -294,7 +298,11 @@ func createEmptySarifReportWithError(errorMessage string) []byte {
 			},
 		},
 	}
-	sarifData, _ := json.MarshalIndent(emptyReport, "", "  ")
+	sarifData, err := json.MarshalIndent(emptyReport, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling SARIF report with error: %v\n", err)
+		return []byte("{}")
+	}
 	return sarifData
 }
 

--- a/utils/sarif.go
+++ b/utils/sarif.go
@@ -27,9 +27,8 @@ type SarifReport struct {
 }
 
 type Run struct {
-	Tool        Tool         `json:"tool"`
-	Results     []Result     `json:"results"`
-	Invocations []Invocation `json:"invocations,omitempty"`
+	Tool    Tool     `json:"tool"`
+	Results []Result `json:"results"`
 }
 
 type Tool struct {
@@ -81,89 +80,18 @@ type ArtifactLocation struct {
 type Region struct {
 	StartLine   int `json:"startLine"`
 	StartColumn int `json:"startColumn"`
-	EndLine     int `json:"endLine"`
-	EndColumn   int `json:"endColumn"`
-}
-
-type Invocation struct {
-	ExecutionSuccessful bool     `json:"executionSuccessful"`
-	ExitCode            int      `json:"exitCode"`
-	ExitSignalName      string   `json:"exitSignalName"`
-	ExitSignalNumber    int      `json:"exitSignalNumber"`
-	Stderr              Artifact `json:"stderr"`
-}
-
-type Artifact struct {
-	Text string `json:"text"`
 }
 
 type MessageText struct {
 	Text string `json:"text"`
 }
 
-// ReadSarifFile reads a SARIF file and returns its contents
-func ReadSarifFile(file string) (SarifReport, error) {
-	data, err := os.ReadFile(file)
-	if err != nil {
-		return SarifReport{}, fmt.Errorf("failed to read SARIF file: %w", err)
-	}
-
-	var sarif SarifReport
-	if err := json.Unmarshal(data, &sarif); err != nil {
-		return SarifReport{}, fmt.Errorf("failed to parse SARIF file: %w", err)
-	}
-
-	return sarif, nil
-}
-
-// WriteSarifFile writes a SARIF report to a file
-func WriteSarifFile(sarif SarifReport, outputFile string) error {
-	out, err := os.Create(outputFile)
-	if err != nil {
-		return fmt.Errorf("failed to create output file: %w", err)
-	}
-	defer out.Close()
-
-	encoder := json.NewEncoder(out)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(sarif); err != nil {
-		return fmt.Errorf("failed to write SARIF: %w", err)
-	}
-
-	return nil
-}
-
-// AddErrorRun adds an error run to an existing SARIF report
-func AddErrorRun(sarif *SarifReport, toolName string, errorMessage string) {
-	errorRun := Run{
-		Tool: Tool{
-			Driver: Driver{
-				Name:    toolName,
-				Version: "1.0.0",
-			},
-		},
-		Invocations: []Invocation{
-			{
-				ExecutionSuccessful: false,
-				ExitCode:            1,
-				ExitSignalName:      "error",
-				ExitSignalNumber:    1,
-				Stderr: Artifact{
-					Text: errorMessage,
-				},
-			},
-		},
-		Results: []Result{},
-	}
-	sarif.Runs = append(sarif.Runs, errorRun)
-}
-
 // ConvertPylintToSarif converts Pylint JSON output to SARIF format
 func ConvertPylintToSarif(pylintOutput []byte) []byte {
 	var issues []PylintIssue
 	if err := json.Unmarshal(pylintOutput, &issues); err != nil {
-		// If parsing fails, return empty SARIF report with error
-		return createEmptySarifReportWithError(err.Error())
+		// If parsing fails, return empty SARIF report
+		return createEmptySarifReport()
 	}
 
 	// Create SARIF report
@@ -180,17 +108,6 @@ func ConvertPylintToSarif(pylintOutput []byte) []byte {
 					},
 				},
 				Results: make([]Result, 0, len(issues)),
-				Invocations: []Invocation{
-					{
-						ExecutionSuccessful: true, // Pylint ran successfully if we got here
-						ExitCode:            0,
-						ExitSignalName:      "",
-						ExitSignalNumber:    0,
-						Stderr: Artifact{
-							Text: "",
-						},
-					},
-				},
 			},
 		},
 	}
@@ -256,53 +173,11 @@ func createEmptySarifReport() []byte {
 						InformationURI: "https://pylint.org",
 					},
 				},
-				Results:     []Result{},
-				Invocations: []Invocation{},
-			},
-		},
-	}
-	sarifData, err := json.MarshalIndent(emptyReport, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling empty SARIF report: %v\n", err)
-		return []byte("{}")
-	}
-	return sarifData
-}
-
-// createEmptySarifReportWithError creates an empty SARIF report with error information
-func createEmptySarifReportWithError(errorMessage string) []byte {
-	emptyReport := SarifReport{
-		Version: "2.1.0",
-		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-		Runs: []Run{
-			{
-				Tool: Tool{
-					Driver: Driver{
-						Name:           "Pylint",
-						Version:        "3.3.6",
-						InformationURI: "https://pylint.org",
-					},
-				},
 				Results: []Result{},
-				Invocations: []Invocation{
-					{
-						ExecutionSuccessful: false,
-						ExitCode:            1,
-						ExitSignalName:      "error",
-						ExitSignalNumber:    1,
-						Stderr: Artifact{
-							Text: errorMessage,
-						},
-					},
-				},
 			},
 		},
 	}
-	sarifData, err := json.MarshalIndent(emptyReport, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling SARIF report with error: %v\n", err)
-		return []byte("{}")
-	}
+	sarifData, _ := json.MarshalIndent(emptyReport, "", "  ")
 	return sarifData
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling in the analysis tools and ensure that errors are properly propagated and logged. The most important changes include modifying the analysis functions to return errors, updating the `runTool` function to handle these errors, and adding error handling in the tool runners.

Error handling improvements:

* [`cmd/analyze.go`](diffhunk://#diff-4d578b2f3d178fd7a93e4c290082b78ed6f70f5c3e99dd31c42d1a124f7346dfL191-R217): Modified `runEslintAnalysis`, `runTrivyAnalysis`, `runPmdAnalysis`, and `runPylintAnalysis` functions to return errors instead of logging fatal errors directly. Updated `runTool` function to handle these errors and log appropriate messages. [[1]](diffhunk://#diff-4d578b2f3d178fd7a93e4c290082b78ed6f70f5c3e99dd31c42d1a124f7346dfL191-R217) [[2]](diffhunk://#diff-4d578b2f3d178fd7a93e4c290082b78ed6f70f5c3e99dd31c42d1a124f7346dfL268-R262) [[3]](diffhunk://#diff-4d578b2f3d178fd7a93e4c290082b78ed6f70f5c3e99dd31c42d1a124f7346dfL299-R313)

Tool runner updates:

* [`tools/eslintRunner.go`](diffhunk://#diff-34f3f2cb332b9271449503173a3a66a671bddc672be96e164081456c8dde8a00L13-R14): Modified `RunEslint` function to return an error if the command fails, except when ESLint returns 1 due to finding issues. [[1]](diffhunk://#diff-34f3f2cb332b9271449503173a3a66a671bddc672be96e164081456c8dde8a00L13-R14) [[2]](diffhunk://#diff-34f3f2cb332b9271449503173a3a66a671bddc672be96e164081456c8dde8a00L57-R67)
* [`tools/pmdRunner.go`](diffhunk://#diff-7deef797edba5219fd1423db5c2233451fa7e077e41058caf659197c2ed4da8dL59-R60): Updated `RunPmd` function to return a formatted error message if the command fails.
* [`tools/pylintRunner.go`](diffhunk://#diff-a212634e28d40247a3f8934654a61efa2bdcd310bbc70c9d6741de5c2c0e426fL62-R62): Adjusted error handling in `RunPylint` function to return a formatted error message.
* [`tools/trivyRunner.go`](diffhunk://#diff-377a74394b80fd2bbcfb3422ece6afaa77da3955ad32b4fc5aa8a993b49be42dL38-R43): Modified `RunTrivy` function to return a formatted error message if the command fails.