### PR TITLE
feature: Adds support for codacy.yml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,7 +110,15 @@ func NewConfigType(repositoryDirectory string, repositoryCache string, globalCac
 	c.toolsDirectory = filepath.Join(c.globalCacheDirectory, "tools")
 	c.toolsConfigDirectory = filepath.Join(c.localCodacyDirectory, "tools-configs")
 
-	c.projectConfigFile = filepath.Join(c.localCodacyDirectory, "codacy.yaml")
+	// If codacy.yml exists, we should rely on it
+	ymlPath := filepath.Join(c.localCodacyDirectory, "codacy.yml")
+	if _, err := os.Stat(ymlPath); err == nil {
+		c.projectConfigFile = ymlPath
+	} else {
+		// Otherwise default to codacy.yaml
+		c.projectConfigFile = filepath.Join(c.localCodacyDirectory, "codacy.yaml")
+	}
+
 	c.cliConfigFile = filepath.Join(c.localCodacyDirectory, "cli-config.yaml")
 
 	c.runtimes = make(map[string]*plugins.RuntimeInfo)


### PR DESCRIPTION
If codacy.yml already exists, rely on it, otherwise rely on codacy.yaml

This check existed in the past, but got removed as we control the configuration file.
However, as a request from @heliocodacy due to users already using that format from the previous version of the CLI, we are restoring it