### PR TITLE
avoiding eslint plugins - PLUTO-1364

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -342,7 +342,7 @@ func createToolFileConfigurations(tool tools.Tool, patternConfiguration []domain
 			if err != nil {
 				return fmt.Errorf("failed to write eslint config: %v", err)
 			}
-			fmt.Println("ESLint configuration created based on Codacy settings")
+			fmt.Println("ESLint configuration created based on Codacy settings. Ignoring plugin rules.")
 		} else {
 			err := createDefaultEslintConfigFile(toolsConfigDir)
 			if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -342,7 +342,7 @@ func createToolFileConfigurations(tool tools.Tool, patternConfiguration []domain
 			if err != nil {
 				return fmt.Errorf("failed to write eslint config: %v", err)
 			}
-			fmt.Println("ESLint configuration created based on Codacy settings. Ignoring plugin rules.")
+			fmt.Println("ESLint configuration created based on Codacy settings. Ignoring plugin rules. ESLint plugins are not supported yet.")
 		} else {
 			err := createDefaultEslintConfigFile(toolsConfigDir)
 			if err != nil {

--- a/tools/eslintConfigCreator_test.go
+++ b/tools/eslintConfigCreator_test.go
@@ -70,7 +70,7 @@ func TestCreateEslintConfigNamedParam(t *testing.T) {
 		[]domain.PatternConfiguration{
 			{
 				PatternDefinition: domain.PatternDefinition{
-					Id: "consistent-return",
+					Id: "ESLint8_consistent-return",
 				},
 				Parameters: []domain.ParameterConfiguration{
 					{
@@ -94,7 +94,7 @@ func TestCreateEslintConfigUnnamedAndNamedParam(t *testing.T) {
 		[]domain.PatternConfiguration{
 			{
 				PatternDefinition: domain.PatternDefinition{
-					Id: "consistent-return",
+					Id: "ESLint8_consistent-return",
 				},
 				Parameters: []domain.ParameterConfiguration{
 					{
@@ -117,19 +117,18 @@ func TestCreateEslintConfigUnnamedAndNamedParam(t *testing.T) {
 ];`)
 }
 
-func TestCreateEslintConfigSupportPlugins(t *testing.T) {
+func TestCreateEslintConfigDoNotSupportPlugins(t *testing.T) {
 	testConfig(t,
 		[]domain.PatternConfiguration{
 			{
 				PatternDefinition: domain.PatternDefinition{
-					Id: "plugin/consistent-return",
+					Id: "ESLint8_plugin_consistent-return",
 				},
 			},
 		},
 		`export default [
     {
         rules: {
-          "plugin/consistent-return": "error",
         }
     }
 ];`)


### PR DESCRIPTION
# Do not process ESLint plugin rules when not using local configuration

## Description

When running ESLint without a local configuration file, handling ESLint plugins (especially with ESLint 8) has proven to be challenging due to:

1. Complex plugin resolution and loading mechanisms in ESLint 8
2. Difficulties in managing plugin dependencies and their peer dependencies
3. Potential conflicts between different plugin versions
4. Increased complexity in maintaining a reliable plugin ecosystem across different environments

As a temporary solution, this PR modifies the ESLint configuration generator to:
- Skip all plugin rules (rules containing "/") when generating the configuration
- Only process core ESLint rules
- Keep all existing functionality for core rules including parameters and error levels

This change ensures more reliable ESLint analysis when running without local configuration while we work on a more comprehensive solution for plugin support.

## Changes

- Modified `CreateEslintConfig` to filter out plugin rules
- Updated tests to reflect new behavior
- Renamed test case to `TestCreateEslintConfigDoNotSupportPlugins` for clarity

## Notes

- This change only affects ESLint analysis when running without a local configuration file
- Projects using local ESLint configuration files will continue to work as before with full plugin support
- We plan to revisit plugin support in the future with a more robust solution
