### PR TITLE
feature: using API repo languages to create languages-config file - PLUTO-1402

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,9 +1,11 @@
 runtimes:
     - node@22.2.0
     - python@3.11.11
+    - dart@3.7.2
 tools:
     - eslint@8.57.0
     - trivy@0.59.1
     - pylint@3.3.6
     - pmd@6.55.0
     - semgrep@1.78.0
+    - dartanalyzer@3.7.2

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,11 +1,9 @@
 runtimes:
     - node@22.2.0
     - python@3.11.11
-    - dart@3.7.2
 tools:
-    - eslint@9.3.0
+    - eslint@8.57.0
     - trivy@0.59.1
     - pylint@3.3.6
     - pmd@6.55.0
-    - dartanalyzer@3.7.2
     - semgrep@1.78.0

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -268,7 +268,7 @@ func buildRepositoryConfigurationFiles(token string) error {
 	}
 
 	// Generate languages configuration based on API tools response
-	if err := tools.CreateLanguagesConfigFile(apiTools, toolsConfigDir, uuidToName); err != nil {
+	if err := tools.CreateLanguagesConfigFile(apiTools, toolsConfigDir, uuidToName, token, initFlags.provider, initFlags.organization, initFlags.repository); err != nil {
 		return fmt.Errorf("failed to create languages configuration file: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	go4.org v0.0.0-20200411211856-f5505b9728dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/therootcompany/xz v1.0.1 h1:CmOtsn1CbtmyYiusbfmhmkpAAETj0wBIH6kCYaX+xzw=
 github.com/therootcompany/xz v1.0.1/go.mod h1:3K3UH1yCKgBneZYhuQUvJ9HPD19UEXEI0BWbMn8qNMY=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/tools/eslintRunner_test.go
+++ b/tools/eslintRunner_test.go
@@ -25,7 +25,7 @@ func TestRunEslintToFile(t *testing.T) {
 
 	repositoryToAnalyze := filepath.Join(testDirectory, "src")
 	expectedSarifFile := filepath.Join(testDirectory, "expected.sarif")
-	eslintInstallationDirectory := filepath.Join(homeDirectory, ".cache/codacy/tools/eslint@9.3.0")
+	eslintInstallationDirectory := filepath.Join(homeDirectory, ".cache/codacy/tools/eslint@8.57.0")
 	nodeBinary := "node"
 
 	RunEslint(repositoryToAnalyze, eslintInstallationDirectory, nodeBinary, nil, false, tempResultFile, "sarif")

--- a/tools/language_config.go
+++ b/tools/language_config.go
@@ -1,14 +1,21 @@
 package tools
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"codacy/cli-v2/utils"
 
 	"gopkg.in/yaml.v3"
 )
+
+const CodacyApiBase = "https://app.codacy.com"
 
 // ToolLanguageInfo contains language and extension information for a tool
 type ToolLanguageInfo struct {
@@ -23,7 +30,7 @@ type LanguagesConfig struct {
 }
 
 // CreateLanguagesConfigFile creates languages-config.yaml based on API response
-func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string) error {
+func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string, apiToken string, provider string, organization string, repository string) error {
 	// Map tool names to their language/extension information
 	toolLanguageMap := map[string]ToolLanguageInfo{
 		"cppcheck": {
@@ -61,6 +68,11 @@ func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap
 	// Build a list of tool language info for enabled tools
 	var configTools []ToolLanguageInfo
 
+	repositoryLanguages, err := getRepositoryLanguages(apiToken, provider, organization, repository)
+	if err != nil {
+		return fmt.Errorf("failed to get repository languages: %w", err)
+	}
+
 	for _, tool := range apiTools {
 		shortName, exists := toolIDMap[tool.Uuid]
 		if !exists {
@@ -71,7 +83,27 @@ func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap
 		// Get language info for this tool
 		langInfo, exists := toolLanguageMap[shortName]
 		if exists {
-			configTools = append(configTools, langInfo)
+			// Special case for Trivy - always include it
+			if shortName == "trivy" {
+				configTools = append(configTools, langInfo)
+				continue
+			}
+
+			// Filter languages based on repository languages
+			var filteredLanguages []string
+			for _, lang := range langInfo.Languages {
+				// Convert both to lowercase for case-insensitive comparison
+				lowerLang := strings.ToLower(lang)
+				if extensions, exists := repositoryLanguages[lowerLang]; exists && len(extensions) > 0 {
+					filteredLanguages = append(filteredLanguages, lang)
+				}
+			}
+
+			// Only add tool if it has languages that exist in the repository
+			if len(filteredLanguages) > 0 {
+				langInfo.Languages = filteredLanguages
+				configTools = append(configTools, langInfo)
+			}
 		}
 	}
 
@@ -101,4 +133,89 @@ func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap
 
 	fmt.Println("Created languages configuration file based on enabled tools")
 	return nil
+}
+
+// https://app.codacy.com/api/v3/organizations/gh/troubleshoot-codacy/repositories/eslint-test-examples/settings/languages
+func getRepositoryLanguages(apiToken string, provider string, organization string, repository string) (map[string][]string, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	url := fmt.Sprintf("%s/api/v3/organizations/%s/%s/repositories/%s/settings/languages",
+		CodacyApiBase,
+		provider,
+		organization,
+		repository)
+
+	// Create a new GET request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set the API token header
+	req.Header.Set("api-token", apiToken)
+
+	// Send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to get repository languages: status code %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Define the response structure
+	type LanguageResponse struct {
+		Name           string   `json:"name"`
+		CodacyDefaults []string `json:"codacyDefaults"`
+		Extensions     []string `json:"extensions"`
+		Enabled        bool     `json:"enabled"`
+		Detected       bool     `json:"detected"`
+	}
+
+	type LanguagesResponse struct {
+		Languages []LanguageResponse `json:"languages"`
+	}
+
+	var response LanguagesResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Create map to store language name -> combined extensions
+	result := make(map[string][]string)
+
+	// Filter and process languages
+	for _, lang := range response.Languages {
+		if lang.Enabled && lang.Detected {
+			// Combine and deduplicate extensions
+			extensions := make(map[string]struct{})
+			for _, ext := range lang.CodacyDefaults {
+				extensions[ext] = struct{}{}
+			}
+			for _, ext := range lang.Extensions {
+				extensions[ext] = struct{}{}
+			}
+
+			// Convert map to slice
+			extSlice := make([]string, 0, len(extensions))
+			for ext := range extensions {
+				extSlice = append(extSlice, ext)
+			}
+
+			// Add to result map with lowercase key for case-insensitive matching
+			result[strings.ToLower(lang.Name)] = extSlice
+		}
+	}
+
+	return result, nil
 }

--- a/tools/language_config.go
+++ b/tools/language_config.go
@@ -30,8 +30,15 @@ type LanguagesConfig struct {
 	Tools []ToolLanguageInfo `yaml:"tools"`
 }
 
+type InitFlags struct {
+	apiToken     string
+	provider     string
+	organization string
+	repository   string
+}
+
 // CreateLanguagesConfigFile creates languages-config.yaml based on API response
-func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string, apiToken string, provider string, organization string, repository string) error {
+func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string, initFlags InitFlags) error {
 	// Map tool names to their language/extension information
 	toolLanguageMap := map[string]ToolLanguageInfo{
 		"cppcheck": {
@@ -69,7 +76,7 @@ func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap
 	// Build a list of tool language info for enabled tools
 	var configTools []ToolLanguageInfo
 
-	repositoryLanguages, err := getRepositoryLanguages(apiToken, provider, organization, repository)
+	repositoryLanguages, err := getRepositoryLanguages(initFlags.apiToken, initFlags.provider, initFlags.organization, initFlags.repository)
 	if err != nil {
 		return fmt.Errorf("failed to get repository languages: %w", err)
 	}

--- a/tools/language_config.go
+++ b/tools/language_config.go
@@ -30,15 +30,8 @@ type LanguagesConfig struct {
 	Tools []ToolLanguageInfo `yaml:"tools"`
 }
 
-type InitFlags struct {
-	apiToken     string
-	provider     string
-	organization string
-	repository   string
-}
-
 // CreateLanguagesConfigFile creates languages-config.yaml based on API response
-func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string, initFlags InitFlags) error {
+func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap map[string]string, apiToken string, provider string, organization string, repository string) error {
 	// Map tool names to their language/extension information
 	toolLanguageMap := map[string]ToolLanguageInfo{
 		"cppcheck": {
@@ -76,7 +69,7 @@ func CreateLanguagesConfigFile(apiTools []Tool, toolsConfigDir string, toolIDMap
 	// Build a list of tool language info for enabled tools
 	var configTools []ToolLanguageInfo
 
-	repositoryLanguages, err := getRepositoryLanguages(initFlags.apiToken, initFlags.provider, initFlags.organization, initFlags.repository)
+	repositoryLanguages, err := getRepositoryLanguages(apiToken, provider, organization, repository)
 	if err != nil {
 		return fmt.Errorf("failed to get repository languages: %w", err)
 	}

--- a/tools/language_config_test.go
+++ b/tools/language_config_test.go
@@ -304,7 +304,7 @@ func TestCreateLanguagesConfigFile_ExtensionsFromRepository(t *testing.T) {
 	pylint := findTool(config.Tools, "pylint")
 	assert.ElementsMatch(t, []string{".py", ".testPy"}, pylint.Extensions)
 	pmd := findTool(config.Tools, "pmd")
-	assert.ElementsMatch(t, []string{".cls", ".app", ".trigger", ".scala", ".rb", ".gemspec"}, pmd.Extensions)
+	assert.ElementsMatch(t, []string{".cls", ".app", ".trigger", ".scala", ".rb", ".gemspec", ".js", ".jsx", ".vue"}, pmd.Extensions)
 }
 
 func findTool(tools []ToolLanguageInfo, name string) ToolLanguageInfo {

--- a/tools/testdata/repositories/test1/expected.sarif
+++ b/tools/testdata/repositories/test1/expected.sarif
@@ -8,7 +8,7 @@
           "name": "ESLint",
           "informationUri": "https://eslint.org",
           "rules": [],
-          "version": "9.3.0"
+          "version": "8.57.0"
         }
       },
       "artifacts": [

--- a/tools/testdata/repositories/test1/src/testdata/repositories/test1/eslint.sarif
+++ b/tools/testdata/repositories/test1/src/testdata/repositories/test1/eslint.sarif
@@ -8,7 +8,7 @@
           "name": "ESLint",
           "informationUri": "https://eslint.org",
           "rules": [],
-          "version": "9.3.0"
+          "version": "8.57.0"
         }
       },
       "artifacts": [

--- a/tools/testdata/repositories/test1/src/testdata/repositories/test1/expected.sarif
+++ b/tools/testdata/repositories/test1/src/testdata/repositories/test1/expected.sarif
@@ -8,7 +8,7 @@
           "name": "ESLint",
           "informationUri": "https://eslint.org",
           "rules": [],
-          "version": "9.3.0"
+          "version": "8.57.0"
         }
       },
       "artifacts": [

--- a/tools/testdata/repositories/test1/src/testdata/repositories/test1/sarif.json
+++ b/tools/testdata/repositories/test1/src/testdata/repositories/test1/sarif.json
@@ -8,7 +8,7 @@
           "name": "ESLint",
           "informationUri": "https://eslint.org",
           "rules": [],
-          "version": "9.3.0"
+          "version": "8.57.0"
         }
       },
       "artifacts": [


### PR DESCRIPTION
# Use configuration from API

## Description
This PR implements the integration with Codacy's API to fetch and use repository language information for tool configuration. It creates a `languages-config.yaml` file that maps tools to their supported languages based on what's detected in the repository.

## Implementation
- Fetches repository language information from Codacy API endpoint
- Creates a mapping between tools and their supported languages/extensions
- Generates `languages-config.yaml` based on the API response
- Special handling for multi-language tools like Trivy

### Important Notes
1. Languages are only included when **both** conditions are met:
   - `enabled: true` - Language is enabled in Codacy settings
   - `detected: true` - Language is actually detected in the repository

2. Extensions are a **union** of:
   - `codacyDefaults` - Default extensions provided by Codacy
   - `extensions` - Custom extensions added by the user

Example API response:
```json
{
  "languages": [
    {
      "name": "Javascript",
      "codacyDefaults": [".js", ".jsx", ".jsm"],
      "extensions": [".vue", ".mjs"],     // Custom extensions
      "enabled": true,
      "detected": true
    },
    {
      "name": "XML",
      "codacyDefaults": [".xml", ".xsl"],
      "extensions": [".wsdl", ".pom"],    // Custom extensions
      "enabled": true,
      "detected": true
    }
  ]
}
```

Generated configuration (`languages-config.yaml`):
```yaml
tools:
    - name: eslint
      languages: [JavaScript]
      extensions: [.js, .jsx, .jsm, .vue, .mjs]  # Combined extensions
    - name: trivy
      languages: [Multiple]
      extensions: []
```

## Testing
- Tested with various repository language combinations
- Verified that only enabled AND detected languages are included
- Confirmed that extensions are correctly merged from both `codacyDefaults` and `extensions`
- Confirmed proper handling of case-sensitive language names