### PR TITLE
feature: Add version command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,17 +9,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git history
       - name: Set up Go
         uses: actions/setup-go@v4
+      - name: Set version info
+        id: version
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "development")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "COMMIT=${COMMIT}" >> $GITHUB_ENV
+          echo "BUILD_TIME=${BUILD_TIME}" >> $GITHUB_ENV
+          echo "LDFLAGS=-X 'codacy/cli-v2/version.Version=${VERSION}' -X 'codacy/cli-v2/version.GitCommit=${COMMIT}' -X 'codacy/cli-v2/version.BuildTime=${BUILD_TIME}'" >> $GITHUB_ENV
       - name: Build CLI for Linux
         run: |
-          GOOS=linux GOARCH=amd64 go build -o cli-v2-linux ./cli-v2.go
+          GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2-linux ./cli-v2.go
       - name: Build CLI for Windows
         run: |
-          GOOS=windows GOARCH=amd64 go build -o cli-v2.exe ./cli-v2.go
+          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2.exe ./cli-v2.go
       - name: Build CLI for macOS
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o cli-v2-macos ./cli-v2.go
+          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2-macos ./cli-v2.go
       - name: Upload CLI binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,25 +13,8 @@ jobs:
           fetch-depth: 0  # Needed for git history
       - name: Set up Go
         uses: actions/setup-go@v4
-      - name: Set version info
-        id: version
-        run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "development")
-          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-          BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "COMMIT=${COMMIT}" >> $GITHUB_ENV
-          echo "BUILD_TIME=${BUILD_TIME}" >> $GITHUB_ENV
-          echo "LDFLAGS=-X 'codacy/cli-v2/version.Version=${VERSION}' -X 'codacy/cli-v2/version.GitCommit=${COMMIT}' -X 'codacy/cli-v2/version.BuildTime=${BUILD_TIME}'" >> $GITHUB_ENV
-      - name: Build CLI for Linux
-        run: |
-          GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2-linux ./cli-v2.go
-      - name: Build CLI for Windows
-        run: |
-          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2.exe ./cli-v2.go
-      - name: Build CLI for macOS
-        run: |
-          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o cli-v2-macos ./cli-v2.go
+      - name: Build CLI for all platforms
+        run: make build-all
       - name: Upload CLI binaries
         uses: actions/upload-artifact@v4
         with:
@@ -50,7 +33,7 @@ jobs:
         uses: actions/setup-go@v4
       - name: Install dependencies from .codacy/codacy.yaml
         run: |
-          go build ./cli-v2.go
+          make build
           ./cli-v2 install
       - name: "Run tests"
         run: |

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git history
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -45,7 +47,6 @@ jobs:
       - name: Make binary executable
         if: matrix.os != 'windows-latest'
         run: chmod +x cli-v2
-
 
       - name: Run tool tests
         if: matrix.os != 'windows-latest'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: build clean
+
+# Get the version from git describe or fallback to a default version
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "development")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+
+# Build flags
+LDFLAGS := -X 'codacy/cli-v2/version.Version=$(VERSION)' -X 'codacy/cli-v2/version.GitCommit=$(COMMIT)' -X 'codacy/cli-v2/version.BuildTime=$(BUILD_TIME)'
+
+# Build the CLI
+build:
+	go build -ldflags "$(LDFLAGS)" -o cli-v2
+
+# Clean build artifacts
+clean:
+	rm -f cli-v2
+
+# Build for all platforms
+build-all: clean
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_linux_amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_darwin_amd64
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_windows_amd64.exe 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean
+.PHONY: build clean build-all build-linux build-darwin build-windows
 
 # Get the version from git describe or fallback to a default version
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "development")
@@ -6,18 +6,29 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 
 # Build flags
-LDFLAGS := -X 'codacy/cli-v2/version.Version=$(VERSION)' -X 'codacy/cli-v2/version.GitCommit=$(COMMIT)' -X 'codacy/cli-v2/version.BuildTime=$(BUILD_TIME)'
+LDFLAGS := -X 'codacy/cli-v2/version.Version=$(VERSION)' \
+           -X 'codacy/cli-v2/version.GitCommit=$(COMMIT)' \
+           -X 'codacy/cli-v2/version.BuildTime=$(BUILD_TIME)'
 
-# Build the CLI
+# Build the CLI for current platform
 build:
 	go build -ldflags "$(LDFLAGS)" -o cli-v2
 
-# Clean build artifacts
-clean:
-	rm -f cli-v2
+# Build for Linux
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2-linux
+
+# Build for macOS
+build-darwin:
+	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2-macos
+
+# Build for Windows
+build-windows:
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2.exe
 
 # Build for all platforms
-build-all: clean
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_linux_amd64
-	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_darwin_amd64
-	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o cli-v2_windows_amd64.exe 
+build-all: build-linux build-darwin build-windows
+
+# Clean build artifacts
+clean:
+	rm -f cli-v2 cli-v2-linux cli-v2-macos cli-v2.exe 

--- a/cli-v2.go
+++ b/cli-v2.go
@@ -5,6 +5,7 @@ import (
 	"codacy/cli-v2/config"
 	config_file "codacy/cli-v2/config-file"
 	"codacy/cli-v2/utils/logger"
+	"codacy/cli-v2/version"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,8 +23,10 @@ func main() {
 		fmt.Printf("Failed to initialize logger: %v\n", err)
 	}
 
-	// Log startup message
-	logger.Debug("Starting Codacy CLI.", logrus.Fields{})
+	// Log startup message and version
+	logger.Info("Starting Codacy CLI", logrus.Fields{
+		"version": version.GetVersion(),
+	})
 
 	// This also setup the config global !
 	configErr := config_file.ReadConfigFile(config.Config.ProjectConfigFile())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/utils/logger"
+	"codacy/cli-v2/version"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:     "codacy-cli",
-	Short:   "Codacy CLI - A command line interface for Codacy",
+	Short:   fmt.Sprintf("Codacy CLI v%s - A command line interface for Codacy", version.GetVersion()),
 	Long:    "",
 	Example: getExampleText(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var rootCmd = &cobra.Command{
@@ -27,20 +26,6 @@ var rootCmd = &cobra.Command{
 		if err := logger.Initialize(logsDir); err != nil {
 			fmt.Printf("Warning: Failed to initialize file logger: %v\n", err)
 		}
-
-		// Create a map to store all flags and their values
-		flags := make(map[string]string)
-		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-			if flag.Changed {
-				// Mask sensitive values
-				value := flag.Value.String()
-				switch flag.Name {
-				case "api-token", "repository-token", "project-token", "codacy-api-token":
-					value = "***"
-				}
-				flags[flag.Name] = value
-			}
-		})
 
 		// Create a masked version of the full command for logging
 		maskedArgs := maskSensitiveArgs(os.Args)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskSensitiveArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "no sensitive flags",
+			args:     []string{"codacy-cli", "analyze", "--tool", "eslint"},
+			expected: []string{"codacy-cli", "analyze", "--tool", "eslint"},
+		},
+		{
+			name:     "api token with space",
+			args:     []string{"codacy-cli", "init", "--api-token", "secret123", "--tool", "eslint"},
+			expected: []string{"codacy-cli", "init", "--api-token", "***", "--tool", "eslint"},
+		},
+		{
+			name:     "api token with equals",
+			args:     []string{"codacy-cli", "init", "--api-token=secret123", "--tool", "eslint"},
+			expected: []string{"codacy-cli", "init", "--api-token=***", "--tool", "eslint"},
+		},
+		{
+			name:     "repository token at end with space",
+			args:     []string{"codacy-cli", "init", "--repository-token", "secret123"},
+			expected: []string{"codacy-cli", "init", "--repository-token", "***"},
+		},
+		{
+			name:     "repository token at end with equals",
+			args:     []string{"codacy-cli", "init", "--repository-token=secret123"},
+			expected: []string{"codacy-cli", "init", "--repository-token=***"},
+		},
+		{
+			name:     "project token at start with space",
+			args:     []string{"codacy-cli", "--project-token", "secret123", "analyze"},
+			expected: []string{"codacy-cli", "--project-token", "***", "analyze"},
+		},
+		{
+			name:     "project token at start with equals",
+			args:     []string{"codacy-cli", "--project-token=secret123", "analyze"},
+			expected: []string{"codacy-cli", "--project-token=***", "analyze"},
+		},
+		{
+			name:     "multiple tokens mixed format",
+			args:     []string{"codacy-cli", "--api-token=secret1", "--project-token", "secret2"},
+			expected: []string{"codacy-cli", "--api-token=***", "--project-token", "***"},
+		},
+		{
+			name:     "token flag at end without value",
+			args:     []string{"codacy-cli", "analyze", "--api-token"},
+			expected: []string{"codacy-cli", "analyze", "--api-token"},
+		},
+		{
+			name:     "empty value after equals",
+			args:     []string{"codacy-cli", "--api-token="},
+			expected: []string{"codacy-cli", "--api-token=***"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			masked := maskSensitiveArgs(tt.args)
+			assert.Equal(t, tt.expected, masked, "masked arguments should match expected")
+		})
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"codacy/cli-v2/version"
+	"fmt"
+	"runtime"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		bold := color.New(color.Bold)
+		cyan := color.New(color.FgCyan)
+
+		fmt.Println()
+		bold.Println("Codacy CLI Version Information")
+		fmt.Println("-----------------------------")
+		cyan.Printf("Version:    ")
+		fmt.Println(version.Version)
+		cyan.Printf("Commit:     ")
+		fmt.Println(version.GitCommit)
+		cyan.Printf("Built:      ")
+		fmt.Println(version.BuildTime)
+		cyan.Printf("Go version: ")
+		fmt.Println(runtime.Version())
+		cyan.Printf("OS/Arch:    ")
+		fmt.Printf("%s/%s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Println()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+// Version information set at build time
+var (
+	// Version is the current version of codacy-cli
+	Version = "development"
+
+	// GitCommit is the git commit hash of the build
+	GitCommit = "unknown"
+
+	// BuildTime is the time the binary was built
+	BuildTime = "unknown"
+)
+
+// GetVersion returns the current version of codacy-cli
+func GetVersion() string {
+	if GitCommit != "unknown" {
+		return Version + " (" + GitCommit + ") built at " + BuildTime
+	}
+	return Version
+}


### PR DESCRIPTION
Showing information on `version` command 
```

Codacy CLI Version Information
-----------------------------
Version:    1.0.0-main.289.5448b24-dirty
Commit:     5448b24
Built:      2025-05-12_14:31:19
Go version: go1.24.1
OS/Arch:    darwin/amd64
```

feature: add version command and enhance CLI logging

- Add version command to display CLI version information
- Add command execution logging with sensitive data masking
- Add version logging to file 