### PR TITLE
Fix: version passing to GoReleaser configuration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,7 +73,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v1"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           git tag ${{ steps.generate-version.outputs.version }}
           git push --tags "https://codacy:${{ secrets.GITHUB_TOKEN }}@github.com/codacy/codacy-cli-v2"
+      - name: Get Go version
+        id: go-version
+        run: echo "VERSION=$(go version | cut -d' ' -f3)" >> $GITHUB_OUTPUT
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -74,3 +77,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOVERSION: ${{ steps.go-version.outputs.VERSION }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
 # For now we are not releasing the CLI, as we are making some quicker iterations
   release:
     needs: [test]
-    # if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
 # For now we are not releasing the CLI, as we are making some quicker iterations
   release:
     needs: [test]
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
+    # if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,6 +59,9 @@ jobs:
       - name: "Git Version"
         id: generate-version
         uses: codacy/git-version@2.8.0
+        with:
+          release-branch: main
+          prefix: v
       - name: "Tag version"
         run: |
           git tag ${{ steps.generate-version.outputs.version }}
@@ -67,8 +70,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          # 'latest', 'nightly', or a semver
-          version: "latest"
+          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
       - -X codacy/cli-v2/version.BuildTime={{.Date}}
       - -X codacy/cli-v2/version.Os={{.Os}}
       - -X codacy/cli-v2/version.Arch={{.Arch}}
-      - -X codacy/cli-v2/version.GoVersion={{.Runtime.Version}}
+      - -X codacy/cli-v2/version.GoVersion={{.Env.GOVERSION}}
     binary: cli-v2
 
 archives:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+project_name: codacy-cli-v2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X codacy/cli-v2/version.Version={{.Version}}
+      - -X codacy/cli-v2/version.GitCommit={{.ShortCommit}}
+      - -X codacy/cli-v2/version.BuildTime={{.Date}}
+      - -X codacy/cli-v2/version.Os={{.Os}}
+      - -X codacy/cli-v2/version.Arch={{.Arch}}
+      - -X codacy/cli-v2/version.GoVersion={{.Runtime.Version}}
+    binary: cli-v2
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: codacy
+    name: codacy-cli-v2 


### PR DESCRIPTION
fix: version passing to GoReleaser configuration 

Fix version command by properly configuring GoReleaser and version injection:
- Update GoReleaser to use version constraint (~> v1) instead of 'latest'
- Fix version information injection through ldflags
- Add proper environment variable handling for Go version

This ensures the version command shows correct build information
and follows GoReleaser's best practices for version constraints.