### PR TITLE
feature: fetch codacy default values for all tools patterns when no token init - PLUTO-1380

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -54,7 +54,7 @@ var initCmd = &cobra.Command{
 
 		if cliLocalMode {
 			fmt.Println()
-			fmt.Println("ℹ️  No project token was specified, skipping fetch configurations")
+			fmt.Println("ℹ️  No project token was specified, fetching codacy default configurations")
 			noTools := []tools.Tool{}
 			err := createConfigurationFiles(noTools, cliLocalMode)
 			if err != nil {
@@ -555,7 +555,6 @@ func createLizardConfigFile(toolsConfigDir string, patternConfiguration []domain
 			patterns[i] = pattern.PatternDefinition
 		}
 
-		fmt.Println("Lizard configuration created based on Codacy settings")
 	}
 
 	content, err := lizard.CreateLizardConfig(patterns)
@@ -588,37 +587,30 @@ func buildDefaultConfigurationFiles(toolsConfigDir string) error {
 			if err != nil {
 				return fmt.Errorf("failed to write eslint config: %v", err)
 			}
-			fmt.Println("ESLint configuration created. Ignoring plugin rules. ESLint plugins are not supported yet.")
 		case Trivy:
 			if err := createTrivyConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Trivy configuration: %w", err)
 			}
-			fmt.Println("Trivy configuration created")
 		case PMD:
 			if err := createPMDConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default PMD configuration: %w", err)
 			}
-			fmt.Println("PMD configuration created")
 		case PyLint:
 			if err := createPylintConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Pylint configuration: %w", err)
 			}
-			fmt.Println("Pylint configuration created")
 		case DartAnalyzer:
 			if err := createDartAnalyzerConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Dart Analyzer configuration: %w", err)
 			}
-			fmt.Println("Dart Analyzer configuration created")
 		case Semgrep:
 			if err := createSemgrepConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Semgrep configuration: %w", err)
 			}
-			fmt.Println("Semgrep configuration created")
 		case Lizard:
 			if err := createLizardConfigFile(toolsConfigDir, patternsConfig); err != nil {
 				return fmt.Errorf("failed to create default Lizard configuration: %w", err)
 			}
-			fmt.Println("Lizard configuration created")
 		}
 	}
 
@@ -635,6 +627,7 @@ const (
 	Lizard       string = "76348462-84b3-409a-90d3-955e90abfb87"
 )
 
+// AvailableTools lists all tool UUIDs supported by Codacy CLI.
 var AvailableTools = []string{
 	ESLint,
 	Trivy,

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	codacyclient "codacy/cli-v2/codacy-client"
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/domain"
 	"codacy/cli-v2/tools"
@@ -23,20 +24,13 @@ import (
 
 const CodacyApiBase = "https://app.codacy.com"
 
-type InitFlags struct {
-	apiToken     string
-	provider     string
-	organization string
-	repository   string
-}
-
-var initFlags InitFlags
+var initFlags domain.InitFlags
 
 func init() {
-	initCmd.Flags().StringVar(&initFlags.apiToken, "api-token", "", "optional codacy api token, if defined configurations will be fetched from codacy")
-	initCmd.Flags().StringVar(&initFlags.provider, "provider", "", "provider (gh/bb/gl) to fetch configurations from codacy, required when api-token is provided")
-	initCmd.Flags().StringVar(&initFlags.organization, "organization", "", "remote organization name to fetch configurations from codacy, required when api-token is provided")
-	initCmd.Flags().StringVar(&initFlags.repository, "repository", "", "remote repository name to fetch configurations from codacy, required when api-token is provided")
+	initCmd.Flags().StringVar(&initFlags.ApiToken, "api-token", "", "optional codacy api token, if defined configurations will be fetched from codacy")
+	initCmd.Flags().StringVar(&initFlags.Provider, "provider", "", "provider (gh/bb/gl) to fetch configurations from codacy, required when api-token is provided")
+	initCmd.Flags().StringVar(&initFlags.Organization, "organization", "", "remote organization name to fetch configurations from codacy, required when api-token is provided")
+	initCmd.Flags().StringVar(&initFlags.Repository, "repository", "", "remote repository name to fetch configurations from codacy, required when api-token is provided")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -56,7 +50,7 @@ var initCmd = &cobra.Command{
 			log.Fatalf("Failed to create tools-configs directory: %v", err)
 		}
 
-		cliLocalMode := len(initFlags.apiToken) == 0
+		cliLocalMode := len(initFlags.ApiToken) == 0
 
 		if cliLocalMode {
 			fmt.Println()
@@ -71,7 +65,7 @@ var initCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 		} else {
-			err := buildRepositoryConfigurationFiles(initFlags.apiToken)
+			err := buildRepositoryConfigurationFiles(initFlags.ApiToken)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -265,7 +259,7 @@ func buildRepositoryConfigurationFiles(token string) error {
 		Timeout: 10 * time.Second,
 	}
 
-	apiTools, err := tools.GetRepositoryTools(CodacyApiBase, token, initFlags.provider, initFlags.organization, initFlags.repository)
+	apiTools, err := tools.GetRepositoryTools(CodacyApiBase, token, initFlags.Provider, initFlags.Organization, initFlags.Repository)
 	if err != nil {
 		return err
 	}
@@ -282,7 +276,7 @@ func buildRepositoryConfigurationFiles(token string) error {
 	}
 
 	// Generate languages configuration based on API tools response
-	if err := tools.CreateLanguagesConfigFile(apiTools, toolsConfigDir, uuidToName, token, initFlags.provider, initFlags.organization, initFlags.repository); err != nil {
+	if err := tools.CreateLanguagesConfigFile(apiTools, toolsConfigDir, uuidToName, token, initFlags.Provider, initFlags.Organization, initFlags.Repository); err != nil {
 		return fmt.Errorf("failed to create languages configuration file: %w", err)
 	}
 
@@ -300,9 +294,9 @@ func buildRepositoryConfigurationFiles(token string) error {
 
 		url := fmt.Sprintf("%s/api/v3/analysis/organizations/%s/%s/repositories/%s/tools/%s/patterns?enabled=true&limit=1000",
 			CodacyApiBase,
-			initFlags.provider,
-			initFlags.organization,
-			initFlags.repository,
+			initFlags.Provider,
+			initFlags.Organization,
+			initFlags.Repository,
 			tool.Uuid)
 
 		// Create a new GET request
@@ -493,6 +487,7 @@ func createDefaultTrivyConfigFile(toolsConfigDir string) error {
 // createDefaultEslintConfigFile creates a default eslint.config.mjs configuration file
 func createDefaultEslintConfigFile(toolsConfigDir string) error {
 	// Use empty tool configuration to get default settings
+	//
 	emptyConfig := []domain.PatternConfiguration{}
 	content := tools.CreateEslintConfig(emptyConfig)
 
@@ -573,16 +568,59 @@ func createLizardConfigFile(toolsConfigDir string, patternConfiguration []domain
 
 // buildDefaultConfigurationFiles creates default configuration files for all tools
 func buildDefaultConfigurationFiles(toolsConfigDir string) error {
-	// Create default Lizard configuration
-	if err := createLizardConfigFile(toolsConfigDir, []domain.PatternConfiguration{}); err != nil {
-		return fmt.Errorf("failed to create default Lizard configuration: %w", err)
-	}
 
-	// Add other default tool configurations here as needed
-	// For example:
-	// if err := createDefaultEslintConfigFile(toolsConfigDir); err != nil {
-	//     return fmt.Errorf("failed to create default ESLint configuration: %w", err)
-	// }
+	for _, tool := range AvailableTools {
+		patternsConfig, err := codacyclient.GetDefaultToolPatternsConfig(initFlags, tool)
+		if err != nil {
+			return fmt.Errorf("failed to get default tool patterns config: %w", err)
+		}
+		switch tool {
+		case ESLint:
+			eslintConfigurationString := tools.CreateEslintConfig(patternsConfig)
+
+			eslintConfigFile, err := os.Create(filepath.Join(toolsConfigDir, "eslint.config.mjs"))
+			if err != nil {
+				return fmt.Errorf("failed to create eslint config file: %v", err)
+			}
+			defer eslintConfigFile.Close()
+
+			_, err = eslintConfigFile.WriteString(eslintConfigurationString)
+			if err != nil {
+				return fmt.Errorf("failed to write eslint config: %v", err)
+			}
+			fmt.Println("ESLint configuration created. Ignoring plugin rules. ESLint plugins are not supported yet.")
+		case Trivy:
+			if err := createTrivyConfigFile(patternsConfig, toolsConfigDir); err != nil {
+				return fmt.Errorf("failed to create default Trivy configuration: %w", err)
+			}
+			fmt.Println("Trivy configuration created")
+		case PMD:
+			if err := createPMDConfigFile(patternsConfig, toolsConfigDir); err != nil {
+				return fmt.Errorf("failed to create default PMD configuration: %w", err)
+			}
+			fmt.Println("PMD configuration created")
+		case PyLint:
+			if err := createPylintConfigFile(patternsConfig, toolsConfigDir); err != nil {
+				return fmt.Errorf("failed to create default Pylint configuration: %w", err)
+			}
+			fmt.Println("Pylint configuration created")
+		case DartAnalyzer:
+			if err := createDartAnalyzerConfigFile(patternsConfig, toolsConfigDir); err != nil {
+				return fmt.Errorf("failed to create default Dart Analyzer configuration: %w", err)
+			}
+			fmt.Println("Dart Analyzer configuration created")
+		case Semgrep:
+			if err := createSemgrepConfigFile(patternsConfig, toolsConfigDir); err != nil {
+				return fmt.Errorf("failed to create default Semgrep configuration: %w", err)
+			}
+			fmt.Println("Semgrep configuration created")
+		case Lizard:
+			if err := createLizardConfigFile(toolsConfigDir, patternsConfig); err != nil {
+				return fmt.Errorf("failed to create default Lizard configuration: %w", err)
+			}
+			fmt.Println("Lizard configuration created")
+		}
+	}
 
 	return nil
 }
@@ -596,3 +634,13 @@ const (
 	Semgrep      string = "6792c561-236d-41b7-ba5e-9d6bee0d548b"
 	Lizard       string = "76348462-84b3-409a-90d3-955e90abfb87"
 )
+
+var AvailableTools = []string{
+	ESLint,
+	Trivy,
+	PMD,
+	PyLint,
+	DartAnalyzer,
+	Semgrep,
+	Lizard,
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/tools"
+	"codacy/cli-v2/utils"
 	"os"
 	"path/filepath"
 	"testing"
@@ -162,7 +163,7 @@ func TestCleanConfigDirectory(t *testing.T) {
 
 	for _, file := range testFiles {
 		filePath := filepath.Join(tempDir, file)
-		err := os.WriteFile(filePath, []byte("test content"), 0644)
+		err := os.WriteFile(filePath, []byte("test content"), utils.DefaultFilePerms)
 		assert.NoError(t, err, "Failed to create test file: %s", filePath)
 	}
 
@@ -209,7 +210,7 @@ func TestInitCommand_NoToken(t *testing.T) {
 	}
 
 	toolsConfigDir := config.Config.ToolsConfigDirectory()
-	if err := os.MkdirAll(toolsConfigDir, 0777); err != nil {
+	if err := os.MkdirAll(toolsConfigDir, utils.DefaultFilePerms); err != nil {
 		t.Fatalf("Failed to create tools-configs directory: %v", err)
 	}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"codacy/cli-v2/config"
 	"codacy/cli-v2/tools"
 	"os"
 	"path/filepath"
@@ -178,4 +179,67 @@ func TestCleanConfigDirectory(t *testing.T) {
 	files, err = os.ReadDir(tempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files), "Expected 0 files after cleaning, got %d", len(files))
+}
+
+func TestInitCommand_NoToken(t *testing.T) {
+	tempDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	assert.NoError(t, err, "Failed to get current working directory")
+	defer os.Chdir(originalWD)
+
+	// Use the real plugins/tools/semgrep/rules.yaml file
+	rulesPath := filepath.Join("plugins", "tools", "semgrep", "rules.yaml")
+	if _, err := os.Stat(rulesPath); os.IsNotExist(err) {
+		t.Skip("plugins/tools/semgrep/rules.yaml not found; skipping test")
+	}
+
+	// Change to the temp directory to simulate a new project
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err, "Failed to change working directory to tempDir")
+
+	// Simulate running init with no token
+	initFlags.ApiToken = ""
+	initFlags.Provider = ""
+	initFlags.Organization = ""
+	initFlags.Repository = ""
+
+	// Call the Run logic from initCmd
+	if err := config.Config.CreateLocalCodacyDir(); err != nil {
+		t.Fatalf("Failed to create local codacy directory: %v", err)
+	}
+
+	toolsConfigDir := config.Config.ToolsConfigDirectory()
+	if err := os.MkdirAll(toolsConfigDir, 0777); err != nil {
+		t.Fatalf("Failed to create tools-configs directory: %v", err)
+	}
+
+	cliLocalMode := len(initFlags.ApiToken) == 0
+	if cliLocalMode {
+		noTools := []tools.Tool{}
+		err := createConfigurationFiles(noTools, cliLocalMode)
+		assert.NoError(t, err, "createConfigurationFiles should not return an error")
+		if err := buildDefaultConfigurationFiles(toolsConfigDir); err != nil {
+			t.Fatalf("Failed to build default configuration files: %v", err)
+		}
+	}
+
+	// Assert that the expected config files are created
+	codacyDir := config.Config.LocalCodacyDirectory()
+	expectedFiles := []string{
+		"tools-configs/eslint.config.mjs",
+		"tools-configs/trivy.yaml",
+		"tools-configs/ruleset.xml",
+		"tools-configs/pylint.rc",
+		"tools-configs/analysis_options.yaml",
+		"tools-configs/semgrep.yaml",
+		"tools-configs/lizard.yaml",
+		"codacy.yaml",
+		"cli-config.yaml",
+	}
+
+	for _, file := range expectedFiles {
+		filePath := filepath.Join(codacyDir, file)
+		_, err := os.Stat(filePath)
+		assert.NoError(t, err, "Expected config file %s to be created", file)
+	}
 }

--- a/codacy-client/client.go
+++ b/codacy-client/client.go
@@ -1,0 +1,131 @@
+package codacyclient
+
+import (
+	"codacy/cli-v2/domain"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const timeout = 10 * time.Second
+const CodacyApiBase = "https://app.codacy.com"
+
+func getRequest(url string, initFlags domain.InitFlags) ([]byte, error) {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("api-token", initFlags.ApiToken)
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		fmt.Printf("Error sending request: %v\n", err)
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		fmt.Println("Error:", url)
+		return nil, errors.New("Failed in request to " + url)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return body, nil
+}
+
+// handlePaginationGeneric fetches all paginated results of type T using a provided fetchPage function.
+//   - baseURL: the base URL for the paginated API
+//   - initialCursor: the initial cursor (empty string for first page)
+//   - fetchPage: a function that fetches a page and returns ([]T, nextCursor, error)
+//
+// Returns a slice of all results of type T and any error encountered.
+func handlePaginationGeneric[T any](
+	baseURL string,
+	initialCursor string,
+	fetchPage func(url string) ([]T, string, error),
+) ([]T, error) {
+	var allResults []T
+	cursor := initialCursor
+	firstRequest := true
+
+	for {
+		pageURL := baseURL
+		if !firstRequest && cursor != "" {
+			if pageURL[len(pageURL)-1] == '?' || pageURL[len(pageURL)-1] == '&' {
+				pageURL += fmt.Sprintf("cursor=%s", cursor)
+			} else {
+				pageURL += fmt.Sprintf("&cursor=%s", cursor)
+			}
+		}
+		firstRequest = false
+
+		results, nextCursor, err := fetchPage(pageURL)
+		if err != nil {
+			return nil, err
+		}
+		allResults = append(allResults, results...)
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	return allResults, nil
+}
+
+func GetDefaultToolPatternsConfig(initFlags domain.InitFlags, toolUUID string) ([]domain.PatternConfiguration, error) {
+	baseURL := fmt.Sprintf("%s/api/v3/tools/%s/patterns?enabled=true", CodacyApiBase, toolUUID)
+
+	fetchPage := func(url string) ([]domain.PatternConfiguration, string, error) {
+		response, err := getRequest(url, initFlags)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get patterns page: %w", err)
+		}
+
+		var objmap map[string]json.RawMessage
+		if err := json.Unmarshal(response, &objmap); err != nil {
+			return nil, "", fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+
+		var patterns []domain.PatternDefinition
+		if err := json.Unmarshal(objmap["data"], &patterns); err != nil {
+			return nil, "", fmt.Errorf("failed to unmarshal patterns: %w", err)
+		}
+
+		patternConfigurations := make([]domain.PatternConfiguration, len(patterns))
+		for i, pattern := range patterns {
+			patternConfigurations[i] = domain.PatternConfiguration{
+				PatternDefinition: pattern,
+				Parameters:        pattern.Parameters,
+				Enabled:           pattern.Enabled,
+			}
+		}
+
+		var pagination domain.Pagination
+		if objmap["pagination"] != nil {
+			if err := json.Unmarshal(objmap["pagination"], &pagination); err != nil {
+				return nil, "", fmt.Errorf("failed to unmarshal pagination: %w", err)
+			}
+		}
+
+		return patternConfigurations, pagination.Cursor, nil
+	}
+
+	return handlePaginationGeneric(baseURL, "", fetchPage)
+}

--- a/codacy-client/client.go
+++ b/codacy-client/client.go
@@ -46,19 +46,32 @@ func getRequest(url string, initFlags domain.InitFlags) ([]byte, error) {
 	return body, nil
 }
 
-// handlePaginationGeneric fetches all paginated results of type T using a provided fetchPage function.
+// GetPage fetches a single page of results from the API and returns the data and next cursor
+func GetPage[T any](
+	url string,
+	initFlags domain.InitFlags,
+	parser func([]byte) ([]T, string, error),
+) ([]T, string, error) {
+	response, err := getRequest(url, initFlags)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get page: %w", err)
+	}
+	return parser(response)
+}
+
+// getAllPages fetches all pages of results from a paginated API endpoint
 //   - baseURL: the base URL for the paginated API
-//   - initialCursor: the initial cursor (empty string for first page)
-//   - fetchPage: a function that fetches a page and returns ([]T, nextCursor, error)
+//   - initFlags: the API token and other flags for authentication
+//   - parser: a function that parses the response body into the desired type and returns ([]T, nextCursor, error)
 //
 // Returns a slice of all results of type T and any error encountered.
-func handlePaginationGeneric[T any](
+func getAllPages[T any](
 	baseURL string,
-	initialCursor string,
-	fetchPage func(url string) ([]T, string, error),
+	initFlags domain.InitFlags,
+	parser func([]byte) ([]T, string, error),
 ) ([]T, error) {
 	var allResults []T
-	cursor := initialCursor
+	cursor := ""
 	firstRequest := true
 
 	for {
@@ -75,7 +88,7 @@ func handlePaginationGeneric[T any](
 		}
 		firstRequest = false
 
-		results, nextCursor, err := fetchPage(pageURL)
+		results, nextCursor, err := GetPage[T](pageURL, initFlags, parser)
 		if err != nil {
 			return nil, err
 		}
@@ -90,43 +103,48 @@ func handlePaginationGeneric[T any](
 	return allResults, nil
 }
 
-func GetDefaultToolPatternsConfig(initFlags domain.InitFlags, toolUUID string) ([]domain.PatternConfiguration, error) {
-	baseURL := fmt.Sprintf("%s/api/v3/tools/%s/patterns?enabled=true", CodacyApiBase, toolUUID)
-
-	fetchPage := func(url string) ([]domain.PatternConfiguration, string, error) {
-		response, err := getRequest(url, initFlags)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to get patterns page: %w", err)
-		}
-
-		var objmap map[string]json.RawMessage
-		if err := json.Unmarshal(response, &objmap); err != nil {
-			return nil, "", fmt.Errorf("failed to unmarshal response: %w", err)
-		}
-
-		var patterns []domain.PatternDefinition
-		if err := json.Unmarshal(objmap["data"], &patterns); err != nil {
-			return nil, "", fmt.Errorf("failed to unmarshal patterns: %w", err)
-		}
-
-		patternConfigurations := make([]domain.PatternConfiguration, len(patterns))
-		for i, pattern := range patterns {
-			patternConfigurations[i] = domain.PatternConfiguration{
-				PatternDefinition: pattern,
-				Parameters:        pattern.Parameters,
-				Enabled:           pattern.Enabled,
-			}
-		}
-
-		var pagination domain.Pagination
-		if objmap["pagination"] != nil {
-			if err := json.Unmarshal(objmap["pagination"], &pagination); err != nil {
-				return nil, "", fmt.Errorf("failed to unmarshal pagination: %w", err)
-			}
-		}
-
-		return patternConfigurations, pagination.Cursor, nil
+// parsePatternConfigurations parses the response body into pattern configurations
+func parsePatternConfigurations(response []byte) ([]domain.PatternConfiguration, string, error) {
+	var objmap map[string]json.RawMessage
+	if err := json.Unmarshal(response, &objmap); err != nil {
+		return nil, "", fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	return handlePaginationGeneric(baseURL, "", fetchPage)
+	var patterns []domain.PatternDefinition
+	if err := json.Unmarshal(objmap["data"], &patterns); err != nil {
+		return nil, "", fmt.Errorf("failed to unmarshal patterns: %w", err)
+	}
+
+	patternConfigurations := make([]domain.PatternConfiguration, len(patterns))
+	for i, pattern := range patterns {
+		patternConfigurations[i] = domain.PatternConfiguration{
+			PatternDefinition: pattern,
+			Parameters:        pattern.Parameters,
+			Enabled:           pattern.Enabled,
+		}
+	}
+
+	var pagination domain.Pagination
+	if objmap["pagination"] != nil {
+		if err := json.Unmarshal(objmap["pagination"], &pagination); err != nil {
+			return nil, "", fmt.Errorf("failed to unmarshal pagination: %w", err)
+		}
+	}
+
+	return patternConfigurations, pagination.Cursor, nil
+}
+
+func GetDefaultToolPatternsConfig(initFlags domain.InitFlags, toolUUID string) ([]domain.PatternConfiguration, error) {
+	baseURL := fmt.Sprintf("%s/api/v3/tools/%s/patterns?enabled=true", CodacyApiBase, toolUUID)
+	return getAllPages(baseURL, initFlags, parsePatternConfigurations)
+}
+
+func GetRepositoryToolPatterns(initFlags domain.InitFlags, toolUUID string) ([]domain.PatternConfiguration, error) {
+	baseURL := fmt.Sprintf("%s/api/v3/analysis/organizations/%s/%s/repositories/%s/tools/%s/patterns?enabled=true",
+		CodacyApiBase,
+		initFlags.Provider,
+		initFlags.Organization,
+		initFlags.Repository,
+		toolUUID)
+	return getAllPages(baseURL, initFlags, parsePatternConfigurations)
 }

--- a/codacy-client/client_test.go
+++ b/codacy-client/client_test.go
@@ -1,0 +1,82 @@
+package codacyclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"codacy/cli-v2/domain"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRequest_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": "ok"}`))
+	}))
+	defer ts.Close()
+
+	initFlags := domain.InitFlags{ApiToken: "dummy"}
+	resp, err := getRequest(ts.URL, initFlags)
+	assert.NoError(t, err)
+	assert.Contains(t, string(resp), "ok")
+}
+
+func TestGetRequest_Failure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	initFlags := domain.InitFlags{ApiToken: "dummy"}
+	_, err := getRequest(ts.URL, initFlags)
+	assert.Error(t, err)
+}
+
+func TestHandlePaginationGeneric(t *testing.T) {
+	type testItem struct{ Value int }
+	pages := [][]testItem{
+		{{Value: 1}, {Value: 2}},
+		{{Value: 3}},
+	}
+	calls := 0
+	fetchPage := func(url string) ([]testItem, string, error) {
+		if calls < len(pages) {
+			page := pages[calls]
+			calls++
+			if calls < len(pages) {
+				return page, "next", nil
+			}
+			return page, "", nil
+		}
+		return nil, "", nil
+	}
+	results, err := handlePaginationGeneric[testItem]("base", "", fetchPage)
+	assert.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+func TestGetDefaultToolPatternsConfig_Empty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"data":       []interface{}{},
+			"pagination": map[string]interface{}{"cursor": ""},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	// TODO: Refactor GetDefaultToolPatternsConfig to accept a baseURL for easier testing
+	// oldBase := CodacyApiBase
+	// CodacyApiBase = ts.URL
+	// defer func() { CodacyApiBase = oldBase }()
+
+	// Placeholder: test cannot be run until function is refactored for testability
+	_ = ts // avoid unused warning
+	// initFlags := domain.InitFlags{ApiToken: "dummy"}
+	// patterns, err := GetDefaultToolPatternsConfig(initFlags, "tool-uuid")
+	// assert.NoError(t, err)
+	// assert.Empty(t, patterns)
+}

--- a/domain/initFlags.go
+++ b/domain/initFlags.go
@@ -1,0 +1,8 @@
+package domain
+
+type InitFlags struct {
+	ApiToken     string
+	Provider     string
+	Organization string
+	Repository   string
+}

--- a/domain/pagination.go
+++ b/domain/pagination.go
@@ -1,0 +1,7 @@
+package domain
+
+type Pagination struct {
+	Cursor string `json:"cursor"`
+	Limit  int    `json:"limit"`
+	Total  int    `json:"total"`
+}

--- a/domain/patternConfiguration.go
+++ b/domain/patternConfiguration.go
@@ -24,5 +24,4 @@ type PatternConfiguration struct {
 	PatternDefinition PatternDefinition `json:"patternDefinition"`
 	Parameters        []ParameterConfiguration
 	Enabled           bool `json:"enabled"`
-	IsCustom          bool `json:"isCustom"`
 }


### PR DESCRIPTION
# Use Codacy Default Patterns when no Token is provided

## Overview
This PR introduces two main improvements:
1. Use Codacy's default patterns for each tool when no API token is provided
2. Add new endpoint in `codacy-client` package to fetch patterns for supported tools

## Changes

### Default Patterns Support
- When initializing without an API token, the CLI now fetches and uses Codacy's default patterns for each tool
- This ensures consistent behavior across all installations, even in local mode
- Default patterns are fetched from Codacy's API and stored in the local configuration
- Affects all supported tools: ESLint, PMD, Pylint, Trivy, DartAnalyzer, etc.

### New Pattern Fetching Endpoint
- Added new `GetDefaultToolPatternsConfig` function in `codacy-client` package
- This endpoint handles fetching patterns for any supported tool
- Implemented generic pagination handling for consistent API response processing
- Note: This is the first step towards centralizing API requests. Future PRs will move other API interactions to this package.
