### PR TITLE
fix: semgrep sarif to not put all rules in output

### DIFF
--- a/tools/dartanalyzerRunner.go
+++ b/tools/dartanalyzerRunner.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,9 +42,9 @@ func RunDartAnalyzer(workDirectory string, installationDirectory string, binary 
 	}
 
 	if !configExists {
-		fmt.Println("No config file found, using tool defaults")
+		log.Println("No config file found, using tool defaults")
 	} else {
-		fmt.Println("Config file found, using it")
+		log.Println("Config file found, using it")
 	}
 
 	// For SARIF output, we need to capture the output and transform it

--- a/tools/enigmaRunner.go
+++ b/tools/enigmaRunner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,10 +33,10 @@ func RunEnigma(workDirectory string, installationDirectory string, binary string
 	}
 
 	if configExists != "" {
-		println("Config file found, using it")
+		log.Println("Config file found, using it")
 		args = append(args, "--configuration-file", configExists)
 	} else {
-		println("No config file found, using tool defaults")
+		log.Println("No config file found, using tool defaults")
 
 	}
 

--- a/tools/semgrepRunner.go
+++ b/tools/semgrepRunner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"codacy/cli-v2/config"
+	"codacy/cli-v2/utils"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,25 +10,9 @@ import (
 	"path/filepath"
 )
 
-// SarifReport represents the structure of a SARIF report
-type SarifReport struct {
-	Version string `json:"version"`
-	Schema  string `json:"$schema"`
-	Runs    []struct {
-		Tool struct {
-			Driver struct {
-				Name  string `json:"name"`
-				Rules []any  `json:"rules,omitempty"`
-			} `json:"driver"`
-		} `json:"tool"`
-		Results     []any `json:"results"`
-		Invocations []any `json:"invocations,omitempty"`
-	} `json:"runs"`
-}
-
 // filterRuleDefinitions removes rule definitions from SARIF output
 func filterRuleDefinitions(sarifData []byte) ([]byte, error) {
-	var report SarifReport
+	var report utils.SarifReport
 	if err := json.Unmarshal(sarifData, &report); err != nil {
 		return nil, fmt.Errorf("failed to parse SARIF data: %w", err)
 	}


### PR DESCRIPTION
When semgrep is run with --sarif flag, it adds all rules to output (there is no flag to suppress this ).
This causing our output file to be like 30K lines (for the project I tested) when we have zero findings ⚠️ 


- Updated logging in dartanalyzerRunner.go and enigmaRunner.go to use log.Println instead of fmt.Println for better log management.
- Enhanced semgrepRunner.go to include SARIF output processing, filtering rule definitions, and writing filtered results to specified output files.