### PR TITLE
Improve lizard config behaviour

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -402,10 +402,7 @@ func runLizardAnalysis(workDirectory string, pathsToCheck []string, outputFile s
 		}
 	} else {
 		fmt.Println("No configuration file found for Lizard, using default patterns, run init with repository token to get a custom configuration")
-		patterns, err = tools.FetchDefaultEnabledPatterns(Lizard)
-		if err != nil {
-			return fmt.Errorf("failed to fetch default patterns: %v", err)
-		}
+		patterns = []domain.PatternDefinition{}
 	}
 
 	return lizard.RunLizard(workDirectory, lizardBinary, pathsToCheck, outputFile, outputFormat, patterns)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -541,19 +541,10 @@ func cleanConfigDirectory(toolsConfigDir string) error {
 }
 
 func createLizardConfigFile(toolsConfigDir string, patternConfiguration []domain.PatternConfiguration) error {
-	var patterns []domain.PatternDefinition
 
-	if len(patternConfiguration) == 0 {
-		var err error
-		patterns, err = tools.FetchDefaultEnabledPatterns(Lizard)
-		if err != nil {
-			return err
-		}
-	} else {
-		patterns = make([]domain.PatternDefinition, len(patternConfiguration))
-		for i, pattern := range patternConfiguration {
-			patterns[i] = pattern.PatternDefinition
-		}
+	patterns := make([]domain.PatternDefinition, len(patternConfiguration))
+	for i, pattern := range patternConfiguration {
+		patterns[i] = pattern.PatternDefinition
 
 	}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"codacy/cli-v2/config"
+	"codacy/cli-v2/domain"
 	"codacy/cli-v2/tools"
 	"codacy/cli-v2/utils"
 	"os"
@@ -243,4 +244,30 @@ func TestInitCommand_NoToken(t *testing.T) {
 		_, err := os.Stat(filePath)
 		assert.NoError(t, err, "Expected config file %s to be created", file)
 	}
+}
+
+func TestCreateLizardConfigFile_EmptyAndNonEmpty(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Case 1: Empty patternConfiguration
+	err := createLizardConfigFile(tempDir, []domain.PatternConfiguration{})
+	assert.NoError(t, err, "Should not error with empty patternConfiguration")
+	lizardFile := filepath.Join(tempDir, "lizard.yaml")
+	_, err = os.Stat(lizardFile)
+	assert.NoError(t, err, "lizard.yaml should be created for empty input")
+
+	// Case 2: Non-empty patternConfiguration
+	patterns := []domain.PatternConfiguration{
+		{
+			PatternDefinition: domain.PatternDefinition{
+				Id:      "Lizard_1",
+				Enabled: true,
+			},
+		},
+	}
+	err = createLizardConfigFile(tempDir, patterns)
+	assert.NoError(t, err, "Should not error with non-empty patternConfiguration")
+	content, err := os.ReadFile(lizardFile)
+	assert.NoError(t, err, "Should be able to read lizard.yaml")
+	assert.NotEmpty(t, content, "lizard.yaml should not be empty for non-empty input")
 }


### PR DESCRIPTION
based on #119 

we were fetching codacy default patterns when no patterns existed we should just keep as it is defined in the repo. 