### PR TITLE
fix eslint config creation and using default 8.57.0 instead 9.3.0 (when init without token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The tool is invoked using the `codacy-cli` command, and provides two main comman
   runtimes:
       - node@22.2.0
   tools:
-      - eslint@9.3.0
+      - eslint@8.57.0
   
 - **`codacy-cli install`**: Command to install the specified node and eslint versions before running analysis.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -138,7 +138,7 @@ func configFileTemplate(tools []tools.Tool) string {
 
 	// Default versions
 	defaultVersions := map[string]string{
-		ESLint:       "9.3.0",
+		ESLint:       "8.57.0",
 		Trivy:        "0.59.1",
 		PyLint:       "3.3.6",
 		PMD:          "6.55.0",

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -24,7 +24,7 @@ func TestConfigFileTemplate(t *testing.T) {
 			expected: []string{
 				"node@22.2.0",
 				"python@3.11.11",
-				"eslint@9.3.0",
+				"eslint@8.57.0",
 				"trivy@0.59.1",
 				"pylint@3.3.6",
 				"pmd@6.55.0",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
   runtimes:
     - node@22.2.0
   tools:
-    - eslint@9.3.0
+    - eslint@8.57.0
 
 ` + color.New(color.FgCyan).Sprint("For more information and examples, visit:") + `
 https://github.com/codacy/codacy-cli-v2

--- a/integration-tests/init-without-token/expected/codacy.yaml
+++ b/integration-tests/init-without-token/expected/codacy.yaml
@@ -4,7 +4,7 @@ runtimes:
     - dart@3.7.2
     - java@17.0.10
 tools:
-    - eslint@9.3.0
+    - eslint@8.57.0
     - trivy@0.59.1
     - pylint@3.3.6
     - pmd@6.55.0

--- a/tools/eslintConfigCreator_test.go
+++ b/tools/eslintConfigCreator_test.go
@@ -35,7 +35,7 @@ func TestCreateEslintConfigConfig1(t *testing.T) {
 		`export default [
     {
         rules: {
-          "semi": "error",
+          "semi": ["error"],
         }
     }
 ];`)
@@ -129,6 +129,74 @@ func TestCreateEslintConfigDoNotSupportPlugins(t *testing.T) {
 		`export default [
     {
         rules: {
+        }
+    }
+];`)
+}
+
+func TestCreateEslintConfigWithDefaultValues(t *testing.T) {
+	testConfig(t,
+		[]domain.PatternConfiguration{
+			{
+				PatternDefinition: domain.PatternDefinition{
+					Id: "ESLint8_no-fallthrough",
+					Parameters: []domain.ParameterConfiguration{
+						{
+							Name:    "commentPattern",
+							Default: "",
+						},
+						{
+							Name:    "allowEmptyCase",
+							Default: "false",
+						},
+					},
+				},
+				Parameters: []domain.ParameterConfiguration{
+					{
+						Name:  "commentPattern",
+						Value: "", // Empty value with empty default - should be skipped
+					},
+					{
+						Name:  "allowEmptyCase",
+						Value: "", // Empty value with default "false" - should use default
+					},
+				},
+			},
+		},
+		`export default [
+    {
+        rules: {
+          "no-fallthrough": ["error", {"allowEmptyCase": false}],
+        }
+    }
+];`)
+}
+
+func TestCreateEslintConfigWithUnnamedDefaultValues(t *testing.T) {
+	testConfig(t,
+		[]domain.PatternConfiguration{
+			{
+				PatternDefinition: domain.PatternDefinition{
+					Id: "ESLint8_no-inner-declarations",
+					Parameters: []domain.ParameterConfiguration{
+						{
+							Name:    "unnamedParam",
+							Default: "functions",
+						},
+					},
+				},
+				Parameters: []domain.ParameterConfiguration{
+					{
+						Name:  "unnamedParam",
+						Value: "", // Empty value with default "functions" - should use default
+					},
+				},
+			},
+		},
+		`export default [
+    {
+        rules: {
+          "no-inner-declarations": ["error", "functions"],
         }
     }
 ];`)


### PR DESCRIPTION

# Fix ESLint configuration generation

## Changes

### ESLint Configuration Generation
- Fixed handling of named parameters in ESLint rules configuration
- Added support for using default values when parameter values are empty
- Properly formatted boolean parameters (true/false) without quotes
- Ensured all rules use consistent array format `["error", ...]` instead of mixing formats
- Fixed issue where parameters with empty values were incorrectly ignored even when defaults existed

## Benefits
- More accurate and consistent ESLint configurations
- Rules now correctly apply their intended parameters
- Better handling of empty values by using defined defaults
- Improved compatibility with ESLint 8.57.0 which is currently supported in CLI
