### PR TITLE
fix: PMD Parameter Value Parsing

### DIFF
--- a/tools/pmdConfigCreator_test.go
+++ b/tools/pmdConfigCreator_test.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"encoding/xml"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -295,9 +294,6 @@ func TestNonEmptyParameterValue(t *testing.T) {
 
 	obtainedConfig := CreatePmdConfig(config)
 
-	// Debug output
-	fmt.Printf("Generated XML:\n%s\n", obtainedConfig)
-
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)
 	assert.NoError(t, err)
@@ -342,12 +338,7 @@ func TestExactJsonStructure(t *testing.T) {
 		},
 	}
 
-	fmt.Println("Test input:")
-	fmt.Printf("Parameters: %+v\n", config[0].Parameters)
-
 	obtainedConfig := CreatePmdConfig(config)
-	fmt.Println("Generated XML:")
-	fmt.Println(obtainedConfig)
 
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)


### PR DESCRIPTION

# Fix PMD Parameter Value Parsing

## Issue Description
The PMD configuration generator was incorrectly handling parameter values, resulting in empty or missing properties in the generated XML configuration. Rules that should have included property values were being output without their required properties.

**Before Fix (incorrect output):**
```xml
<rule ref="category/pom/errorprone.xml/InvalidDependencyTypes"/>
```

**After Fix (correct output with properties):**
```xml
<rule ref="category/pom/errorprone.xml/InvalidDependencyTypes">
    <properties>
        <property name="validTypes" value="pom,jar,maven-plugin,ejb,war,ear,rar,par"/>
    </properties>
</rule>
```

## Fix
- Modified the parameter value handling to correctly use default values when the explicitly specified value is empty
- Ensured property values are properly included in the generated XML configuration
- Removed debug logs to clean up the code for production use

The PMD ruleset generator now correctly includes all parameter values in the generated configuration files.
