### PR TITLE
[PLUTO-1395] Handle multiple pmd/eslint versions

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -402,7 +402,7 @@ func runLizardAnalysis(workDirectory string, pathsToCheck []string, outputFile s
 		}
 	} else {
 		fmt.Println("No configuration file found for Lizard, using default patterns, run init with repository token to get a custom configuration")
-		patterns, err = tools.FetchDefaultEnabledPatterns(Lizard)
+		patterns, err = tools.FetchDefaultEnabledPatterns(domain.Lizard)
 		if err != nil {
 			return fmt.Errorf("failed to fetch default patterns: %v", err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -153,17 +153,6 @@ func createConfigurationFiles(tools []domain.Tool, cliLocalMode bool) error {
 	return nil
 }
 
-// Map tool UUIDs to their names
-var toolNameMap = map[string]string{
-	ESLint:       "eslint",
-	Trivy:        "trivy",
-	PyLint:       "pylint",
-	PMD:          "pmd",
-	DartAnalyzer: "dartanalyzer",
-	Semgrep:      "semgrep",
-	Lizard:       "lizard",
-}
-
 // RuntimePluginConfig holds the structure of the runtime plugin.yaml file
 type RuntimePluginConfig struct {
 	Name           string `yaml:"name"`
@@ -175,6 +164,8 @@ func configFileTemplate(tools []domain.Tool) string {
 	// Maps to track which tools are enabled
 	toolsMap := make(map[string]bool)
 	toolVersions := make(map[string]string)
+
+	toolsWithLatestVersion, _, _ := KeepToolsWithLatestVersion(tools)
 
 	// Track needed runtimes
 	neededRuntimes := make(map[string]bool)
@@ -189,23 +180,23 @@ func configFileTemplate(tools []domain.Tool) string {
 	runtimeDependencies := plugins.GetToolRuntimeDependencies()
 
 	// Build map of enabled tools with their versions
-	for _, tool := range tools {
+	for _, tool := range toolsWithLatestVersion {
 		toolsMap[tool.Uuid] = true
 		if tool.Version != "" {
 			toolVersions[tool.Uuid] = tool.Version
 		} else {
-			toolName := toolNameMap[tool.Uuid]
-			if defaultVersion, ok := defaultVersions[toolName]; ok {
-				toolVersions[tool.Uuid] = defaultVersion
+			if meta, ok := domain.SupportedToolsMetadata[tool.Uuid]; ok {
+				if defaultVersion, ok := defaultVersions[meta.Name]; ok {
+					toolVersions[tool.Uuid] = defaultVersion
+				}
 			}
 		}
 
 		// Get the tool's runtime dependency
-		toolName := toolNameMap[tool.Uuid]
-		if toolName != "" {
-			if runtime, ok := runtimeDependencies[toolName]; ok {
+		if meta, ok := domain.SupportedToolsMetadata[tool.Uuid]; ok {
+			if runtime, ok := runtimeDependencies[meta.Name]; ok {
 				// Handle special case for dartanalyzer which can use either dart or flutter
-				if toolName == "dartanalyzer" {
+				if meta.Name == "dartanalyzer" {
 					// For now, default to dart runtime
 					neededRuntimes["dart"] = true
 				} else {
@@ -233,15 +224,8 @@ func configFileTemplate(tools []domain.Tool) string {
 			sb.WriteString(fmt.Sprintf("    - %s@%s\n", runtime, runtimeVersions[runtime]))
 		}
 	} else {
-		// In local mode with no tools specified, include only the necessary runtimes
-		supportedTools, err := plugins.GetSupportedTools()
-		if err != nil {
-			log.Printf("Warning: failed to get supported tools: %v", err)
-			return sb.String()
-		}
-
-		// Get runtimes needed by supported tools
-		for toolName := range supportedTools {
+		// If no tools were specified (local mode), include all tools in sorted order
+		for toolName := range defaultVersions {
 			if runtime, ok := runtimeDependencies[toolName]; ok {
 				if toolName == "dartanalyzer" {
 					neededRuntimes["dart"] = true
@@ -250,15 +234,11 @@ func configFileTemplate(tools []domain.Tool) string {
 				}
 			}
 		}
-
-		// Create a sorted slice of runtimes
 		var sortedRuntimes []string
 		for runtime := range neededRuntimes {
 			sortedRuntimes = append(sortedRuntimes, runtime)
 		}
 		sort.Strings(sortedRuntimes)
-
-		// Write sorted runtimes
 		for _, runtime := range sortedRuntimes {
 			sb.WriteString(fmt.Sprintf("    - %s@%s\n", runtime, runtimeVersions[runtime]))
 		}
@@ -266,13 +246,12 @@ func configFileTemplate(tools []domain.Tool) string {
 
 	sb.WriteString("tools:\n")
 
-	// If we have tools from the API (enabled tools), use only those
 	if len(tools) > 0 {
 		// Create a sorted slice of tool names
 		var sortedTools []string
-		for uuid, name := range toolNameMap {
+		for uuid, meta := range domain.SupportedToolsMetadata {
 			if toolsMap[uuid] {
-				sortedTools = append(sortedTools, name)
+				sortedTools = append(sortedTools, meta.Name)
 			}
 		}
 		sort.Strings(sortedTools)
@@ -280,8 +259,8 @@ func configFileTemplate(tools []domain.Tool) string {
 		// Write sorted tools
 		for _, name := range sortedTools {
 			// Find the UUID for this tool name to get its version
-			for uuid, toolName := range toolNameMap {
-				if toolName == name && toolsMap[uuid] {
+			for uuid, meta := range domain.SupportedToolsMetadata {
+				if meta.Name == name && toolsMap[uuid] {
 					version := toolVersions[uuid]
 					sb.WriteString(fmt.Sprintf("    - %s@%s\n", name, version))
 					break
@@ -353,27 +332,31 @@ func buildRepositoryConfigurationFiles(token string) error {
 		return err
 	}
 
-	// Map UUID to tool shortname for lookup
-	uuidToName := map[string]string{
-		ESLint:       "eslint",
-		Trivy:        "trivy",
-		PyLint:       "pylint",
-		PMD:          "pmd",
-		DartAnalyzer: "dartanalyzer",
-		Lizard:       "lizard",
-		Semgrep:      "semgrep",
+	toolsWithLatestVersion, uuidToName, familyToVersions := KeepToolsWithLatestVersion(apiTools)
+
+	for family, versions := range familyToVersions {
+		if len(versions) > 1 {
+			kept := ", "
+			for _, tool := range toolsWithLatestVersion {
+				if domain.SupportedToolsMetadata[tool.Uuid].Name == family {
+					kept = tool.Version
+					break
+				}
+			}
+			fmt.Printf("⚠️  Multiple versions of '%s' detected: [%s], keeping %s\n", family, strings.Join(versions, ", "), kept)
+		}
 	}
 
 	// Generate languages configuration based on API tools response
-	if err := tools.CreateLanguagesConfigFile(apiTools, toolsConfigDir, uuidToName, initFlags); err != nil {
+	if err := tools.CreateLanguagesConfigFile(toolsWithLatestVersion, toolsConfigDir, uuidToName, initFlags); err != nil {
 		return fmt.Errorf("failed to create languages configuration file: %w", err)
 	}
 
 	// Filter out any tools that use configuration file
-	configuredToolsWithUI := tools.FilterToolsByConfigUsage(apiTools)
+	configuredToolsWithUI := tools.FilterToolsByConfigUsage(toolsWithLatestVersion)
 
 	// Create main config files with all enabled API tools
-	err = createConfigurationFiles(apiTools, false)
+	err = createConfigurationFiles(toolsWithLatestVersion, false)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -398,43 +381,48 @@ func buildRepositoryConfigurationFiles(token string) error {
 func createToolFileConfigurations(tool domain.Tool, patternConfiguration []domain.PatternConfiguration) error {
 	toolsConfigDir := config.Config.ToolsConfigDirectory()
 	switch tool.Uuid {
-	case ESLint:
+	case domain.ESLint, domain.ESLint9:
 		err := tools.CreateEslintConfig(toolsConfigDir, patternConfiguration)
 		if err != nil {
 			return fmt.Errorf("failed to write eslint config: %v", err)
 		}
 		fmt.Println("ESLint configuration created based on Codacy settings. Ignoring plugin rules. ESLint plugins are not supported yet.")
-	case Trivy:
+	case domain.Trivy:
 		err := createTrivyConfigFile(patternConfiguration, toolsConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed to create Trivy config: %v", err)
 		}
 		fmt.Println("Trivy configuration created based on Codacy settings")
-	case PMD:
+	case domain.PMD:
 		err := createPMDConfigFile(patternConfiguration, toolsConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed to create PMD config: %v", err)
 		}
-		fmt.Println("PMD configuration created based on Codacy settings")
-	case PyLint:
+	case domain.PMD7:
+		err := createPMD7ConfigFile(patternConfiguration, toolsConfigDir)
+		if err != nil {
+			return fmt.Errorf("failed to create PMD7 config: %v", err)
+		}
+		fmt.Println("PMD7 configuration created based on Codacy settings")
+	case domain.PyLint:
 		err := createPylintConfigFile(patternConfiguration, toolsConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed to create Pylint config: %v", err)
 		}
 		fmt.Println("Pylint configuration created based on Codacy settings")
-	case DartAnalyzer:
+	case domain.DartAnalyzer:
 		err := createDartAnalyzerConfigFile(patternConfiguration, toolsConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed to create Dart Analyzer config: %v", err)
 		}
 		fmt.Println("Dart configuration created based on Codacy settings")
-	case Semgrep:
+	case domain.Semgrep:
 		err := createSemgrepConfigFile(patternConfiguration, toolsConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed to create Semgrep config: %v", err)
 		}
 		fmt.Println("Semgrep configuration created based on Codacy settings")
-	case Lizard:
+	case domain.Lizard:
 		err := createLizardConfigFile(toolsConfigDir, patternConfiguration)
 		if err != nil {
 			return fmt.Errorf("failed to create Lizard config: %v", err)
@@ -445,7 +433,12 @@ func createToolFileConfigurations(tool domain.Tool, patternConfiguration []domai
 }
 
 func createPMDConfigFile(config []domain.PatternConfiguration, toolsConfigDir string) error {
-	pmdConfigurationString := tools.CreatePmdConfig(config)
+	pmdConfigurationString := tools.CreatePmd6Config(config)
+	return os.WriteFile(filepath.Join(toolsConfigDir, "ruleset.xml"), []byte(pmdConfigurationString), utils.DefaultFilePerms)
+}
+
+func createPMD7ConfigFile(config []domain.PatternConfiguration, toolsConfigDir string) error {
+	pmdConfigurationString := tools.CreatePmd7Config(config)
 	return os.WriteFile(filepath.Join(toolsConfigDir, "ruleset.xml"), []byte(pmdConfigurationString), utils.DefaultFilePerms)
 }
 
@@ -529,37 +522,39 @@ func createLizardConfigFile(toolsConfigDir string, patternConfiguration []domain
 
 // buildDefaultConfigurationFiles creates default configuration files for all tools
 func buildDefaultConfigurationFiles(toolsConfigDir string) error {
-	for _, tool := range AvailableTools {
-		patternsConfig, err := codacyclient.GetDefaultToolPatternsConfig(initFlags, tool)
+	for uuid := range domain.SupportedToolsMetadata {
+		patternsConfig, err := codacyclient.GetDefaultToolPatternsConfig(initFlags, uuid)
 		if err != nil {
 			return fmt.Errorf("failed to get default tool patterns config: %w", err)
 		}
-		switch tool {
-		case ESLint:
+		switch uuid {
+		case domain.ESLint:
 			if err := tools.CreateEslintConfig(toolsConfigDir, patternsConfig); err != nil {
 				return fmt.Errorf("failed to create eslint config file: %v", err)
 			}
-		case Trivy:
+		case domain.Trivy:
 			if err := createTrivyConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Trivy configuration: %w", err)
 			}
-		case PMD:
+		case domain.PMD:
 			if err := createPMDConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default PMD configuration: %w", err)
 			}
-		case PyLint:
+		case domain.PMD7, domain.ESLint9:
+			continue
+		case domain.PyLint:
 			if err := createPylintConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Pylint configuration: %w", err)
 			}
-		case DartAnalyzer:
+		case domain.DartAnalyzer:
 			if err := createDartAnalyzerConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Dart Analyzer configuration: %w", err)
 			}
-		case Semgrep:
+		case domain.Semgrep:
 			if err := createSemgrepConfigFile(patternsConfig, toolsConfigDir); err != nil {
 				return fmt.Errorf("failed to create default Semgrep configuration: %w", err)
 			}
-		case Lizard:
+		case domain.Lizard:
 			if err := createLizardConfigFile(toolsConfigDir, patternsConfig); err != nil {
 				return fmt.Errorf("failed to create default Lizard configuration: %w", err)
 			}
@@ -568,23 +563,50 @@ func buildDefaultConfigurationFiles(toolsConfigDir string) error {
 	return nil
 }
 
-const (
-	ESLint       string = "f8b29663-2cb2-498d-b923-a10c6a8c05cd"
-	Trivy        string = "2fd7fbe0-33f9-4ab3-ab73-e9b62404e2cb"
-	PMD          string = "9ed24812-b6ee-4a58-9004-0ed183c45b8f"
-	PyLint       string = "31677b6d-4ae0-4f56-8041-606a8d7a8e61"
-	DartAnalyzer string = "d203d615-6cf1-41f9-be5f-e2f660f7850f"
-	Semgrep      string = "6792c561-236d-41b7-ba5e-9d6bee0d548b"
-	Lizard       string = "76348462-84b3-409a-90d3-955e90abfb87"
-)
+// KeepToolsWithLatestVersion filters the tools to keep only the latest version of each tool family.
+func KeepToolsWithLatestVersion(tools []domain.Tool) (
+	toolsWithLatestVersion []domain.Tool,
+	uuidToName map[string]string,
+	familyToVersions map[string][]string,
+) {
+	latestTools := map[string]domain.Tool{}
+	uuidToName = map[string]string{}
+	seen := map[string][]domain.Tool{}
+	familyToVersions = map[string][]string{}
 
-// AvailableTools lists all tool UUIDs supported by Codacy CLI.
-var AvailableTools = []string{
-	ESLint,
-	Trivy,
-	PMD,
-	PyLint,
-	DartAnalyzer,
-	Semgrep,
-	Lizard,
+	for _, tool := range tools {
+		meta, ok := domain.SupportedToolsMetadata[tool.Uuid]
+		if !ok {
+			continue
+		}
+
+		// Track all tools seen per family
+		seen[meta.Name] = append(seen[meta.Name], tool)
+
+		// Pick the best version
+		current, exists := latestTools[meta.Name]
+		if !exists || domain.SupportedToolsMetadata[current.Uuid].Priority > meta.Priority {
+			latestTools[meta.Name] = tool
+			uuidToName[tool.Uuid] = meta.Name
+		}
+	}
+
+	// Populate final list and version map for logging
+	for family, tools := range seen {
+		var versions []string
+		for _, t := range tools {
+			v := t.Version
+			if v == "" {
+				v = "(unknown)"
+			}
+			versions = append(versions, v)
+		}
+		familyToVersions[family] = versions
+	}
+
+	for _, tool := range latestTools {
+		toolsWithLatestVersion = append(toolsWithLatestVersion, tool)
+	}
+
+	return
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -24,7 +24,7 @@ func TestConfigFileTemplate(t *testing.T) {
 			expected: []string{
 				"node@22.2.0",
 				"python@3.11.11",
-				"eslint@9.3.0",
+				"eslint@8.57.0",
 				"trivy@0.59.1",
 				"pylint@3.3.6",
 				"pmd@6.55.0",

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -35,7 +35,7 @@ func TestConfigFileTemplate(t *testing.T) {
 			name: "only eslint enabled",
 			tools: []domain.Tool{
 				{
-					Uuid:    ESLint,
+					Uuid:    domain.ESLint,
 					Name:    "eslint",
 					Version: "9.4.0",
 				},
@@ -55,7 +55,7 @@ func TestConfigFileTemplate(t *testing.T) {
 			name: "only pylint enabled",
 			tools: []domain.Tool{
 				{
-					Uuid:    PyLint,
+					Uuid:    domain.PyLint,
 					Name:    "pylint",
 					Version: "3.4.0",
 				},
@@ -75,12 +75,12 @@ func TestConfigFileTemplate(t *testing.T) {
 			name: "eslint and trivy enabled",
 			tools: []domain.Tool{
 				{
-					Uuid:    ESLint,
+					Uuid:    domain.ESLint,
 					Name:    "eslint",
 					Version: "9.4.0",
 				},
 				{
-					Uuid:    Trivy,
+					Uuid:    domain.Trivy,
 					Name:    "trivy",
 					Version: "0.60.0",
 				},
@@ -100,22 +100,22 @@ func TestConfigFileTemplate(t *testing.T) {
 			name: "all tools enabled",
 			tools: []domain.Tool{
 				{
-					Uuid:    ESLint,
+					Uuid:    domain.ESLint,
 					Name:    "eslint",
 					Version: "9.4.0",
 				},
 				{
-					Uuid:    Trivy,
+					Uuid:    domain.Trivy,
 					Name:    "trivy",
 					Version: "0.60.0",
 				},
 				{
-					Uuid:    PyLint,
+					Uuid:    domain.PyLint,
 					Name:    "pylint",
 					Version: "3.4.0",
 				},
 				{
-					Uuid:    PMD,
+					Uuid:    domain.PMD,
 					Name:    "pmd",
 					Version: "6.56.0",
 				},

--- a/domain/tool.go
+++ b/domain/tool.go
@@ -16,3 +16,32 @@ type Tool struct {
 		UsesConfigurationFile bool `json:"usesConfigurationFile"`
 	} `json:"settings"`
 }
+
+const (
+	ESLint       string = "f8b29663-2cb2-498d-b923-a10c6a8c05cd"
+	ESLint9      string = "2a30ab97-477f-4769-8b88-af596ce7a94c"
+	Trivy        string = "2fd7fbe0-33f9-4ab3-ab73-e9b62404e2cb"
+	PMD          string = "9ed24812-b6ee-4a58-9004-0ed183c45b8f"
+	PMD7         string = "ed7e8287-707d-485a-a0cb-e211004432c2"
+	PyLint       string = "31677b6d-4ae0-4f56-8041-606a8d7a8e61"
+	DartAnalyzer string = "d203d615-6cf1-41f9-be5f-e2f660f7850f"
+	Semgrep      string = "6792c561-236d-41b7-ba5e-9d6bee0d548b"
+	Lizard       string = "76348462-84b3-409a-90d3-955e90abfb87"
+)
+
+type ToolInfo struct {
+	Name     string
+	Priority int // lower means newer
+}
+
+var SupportedToolsMetadata = map[string]ToolInfo{
+	ESLint9:      {Name: "eslint", Priority: 0},
+	ESLint:       {Name: "eslint", Priority: 1},
+	PMD7:         {Name: "pmd", Priority: 0},
+	PMD:          {Name: "pmd", Priority: 1},
+	PyLint:       {Name: "pylint", Priority: 0},
+	Trivy:        {Name: "trivy", Priority: 0},
+	DartAnalyzer: {Name: "dartanalyzer", Priority: 0},
+	Lizard:       {Name: "lizard", Priority: 0},
+	Semgrep:      {Name: "semgrep", Priority: 0},
+}

--- a/domain/tool.go
+++ b/domain/tool.go
@@ -34,6 +34,7 @@ type ToolInfo struct {
 	Priority int // lower means newer
 }
 
+// SupportedToolsMetadata group same family tools by name
 var SupportedToolsMetadata = map[string]ToolInfo{
 	ESLint9:      {Name: "eslint", Priority: 0},
 	ESLint:       {Name: "eslint", Priority: 1},

--- a/integration-tests/init-with-token/expected/tools-configs/ruleset.xml
+++ b/integration-tests/init-with-token/expected/tools-configs/ruleset.xml
@@ -4,7 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>Codacy PMD Ruleset</description>
-
     <rule ref="category/apex/design.xml/ExcessivePublicCount"/>
     <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
     <rule ref="category/java/codestyle.xml/ShortMethodName"/>

--- a/integration-tests/init-without-token/expected/codacy.yaml
+++ b/integration-tests/init-without-token/expected/codacy.yaml
@@ -5,7 +5,7 @@ runtimes:
     - python@3.11.11
 tools:
     - dartanalyzer@3.7.2
-    - eslint@9.3.0
+    - eslint@8.57.0
     - lizard@1.17.19
     - pmd@6.55.0
     - pylint@3.3.6

--- a/integration-tests/init-without-token/expected/tools-configs/ruleset.xml
+++ b/integration-tests/init-without-token/expected/tools-configs/ruleset.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="Codacy PMD Ruleset"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>Codacy PMD Ruleset</description>
-
     <rule ref="category/apex/design.xml/AvoidDeeplyNestedIfStmts"/>
     <rule ref="category/apex/design.xml/ExcessiveClassLength"/>
     <rule ref="category/apex/design.xml/ExcessiveParameterList"/>

--- a/plugins/tools/eslint/plugin.yaml
+++ b/plugins/tools/eslint/plugin.yaml
@@ -1,6 +1,6 @@
 name: eslint
 description: ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code.
-default_version: 9.3.0
+default_version: 8.57.0
 runtime: node
 runtime_binaries:
   package_manager: npm

--- a/plugins/tools/pmd/plugin.yaml
+++ b/plugins/tools/pmd/plugin.yaml
@@ -5,8 +5,8 @@ runtime: java
 runtime_binaries:
   execution: java
 download:
-  url_template: "https://github.com/pmd/pmd/releases/download/pmd_releases%2F{{.Version}}/pmd-bin-{{.Version}}.zip"
-  file_name_template: pmd-bin-{{.Version}}
+  url_template: "https://github.com/pmd/pmd/releases/download/pmd_releases%2F{{.Version}}/{{if ge .Version \"7.0.0\"}}pmd-dist-{{.Version}}-bin.zip{{else}}pmd-bin-{{.Version}}.zip{{end}}"
+  file_name_template: "{{if ge .Version \"7.0.0\"}}pmd-dist-{{.Version}}-bin{{else}}pmd-bin-{{.Version}}{{end}}"
   extension:
     default: .zip
 environment:
@@ -14,4 +14,4 @@ environment:
   PATH: "{{.RuntimeInstallDir}}/bin:{{.Path}}"
 binaries:
   - name: pmd
-    path: pmd-bin-{{.Version}}/bin/run.sh
+    path: "pmd-bin-{{.Version}}/bin/{{if ge .Version \"7.0.0\"}}pmd{{else}}run.sh{{end}}"

--- a/tools/eslintConfigCreator.go
+++ b/tools/eslintConfigCreator.go
@@ -110,7 +110,10 @@ func CreateEslintConfig(toolsConfigDir string, configuration []domain.PatternCon
 `
 
 	for _, patternConfiguration := range configuration {
-		rule := strings.TrimPrefix(patternConfiguration.PatternDefinition.Id, "ESLint8_")
+		ruleId := patternConfiguration.PatternDefinition.Id
+		ruleId = strings.TrimPrefix(ruleId, "ESLint8_")
+		ruleId = strings.TrimPrefix(ruleId, "ESLint9_")
+		rule := ruleId
 
 		rule, skipRule := removePlugins(rule)
 		if skipRule {

--- a/tools/getTools.go
+++ b/tools/getTools.go
@@ -3,12 +3,7 @@ package tools
 import (
 	codacyClient "codacy/cli-v2/codacy-client"
 	"codacy/cli-v2/domain"
-	"codacy/cli-v2/plugins"
-	"codacy/cli-v2/utils/logger"
 	"fmt"
-	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 func enrichToolsWithVersion(tools []domain.Tool) ([]domain.Tool, error) {
@@ -39,36 +34,16 @@ func GetRepositoryTools(initFlags domain.InitFlags) ([]domain.Tool, error) {
 		return nil, err
 	}
 
-	supportedTools, err := plugins.GetSupportedTools()
-	if err != nil {
-		return nil, err
-	}
-
-	// Print supported tools for debugging
-	logger.Info("Supported tools:", logrus.Fields{
-		"supported_tools": supportedTools,
-	})
-
-	// Filter enabled tools
-	var enabledTools []domain.Tool
-	var unsupportedTools []string
+	enabledTools := make([]domain.Tool, 0)
+	seen := map[string]bool{}
 
 	for _, tool := range tools {
 		if tool.Settings.Enabled {
-			toolName := strings.ToLower(tool.Name)
-			if _, exists := supportedTools[toolName]; exists {
+			if _, ok := domain.SupportedToolsMetadata[tool.Uuid]; ok && !seen[tool.Uuid] {
 				enabledTools = append(enabledTools, tool)
-			} else {
-				unsupportedTools = append(unsupportedTools, tool.Name)
+				seen[tool.Uuid] = true
 			}
 		}
-	}
-
-	// Log unsupported tools once
-	if len(unsupportedTools) > 0 {
-		logger.Warn("Some tools are not supported", logrus.Fields{
-			"unsupported_tools": strings.Join(unsupportedTools, ", "),
-		})
 	}
 
 	return enrichToolsWithVersion(enabledTools)

--- a/tools/pmdConfigCreator_test.go
+++ b/tools/pmdConfigCreator_test.go
@@ -80,7 +80,7 @@ func TestCreatePmdConfig(t *testing.T) {
 	}
 
 	// Generate PMD config
-	generatedConfig := CreatePmdConfig(config)
+	generatedConfig := CreatePmd6Config(config)
 
 	// Read expected ruleset
 	expectedRulesetPath := filepath.Join("testdata", "repositories", "pmd", "expected-ruleset.xml")
@@ -125,7 +125,7 @@ func TestCreatePmdConfigWithDisabledRules(t *testing.T) {
 		},
 	}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)
@@ -171,7 +171,7 @@ func TestCreatePmdConfigEmpty(t *testing.T) {
 
 	config := []domain.PatternConfiguration{}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	assert.Contains(t, obtainedConfig, `name="Default PMD Ruleset"`, "XML should contain the correct ruleset name")
 	assert.Contains(t, obtainedConfig, `xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"`, "XML should contain the correct xmlns")
@@ -207,7 +207,7 @@ func TestCreatePmdConfigEmptyParameterValues(t *testing.T) {
 		},
 	}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)
@@ -266,7 +266,7 @@ func TestEmptyParametersAreSkipped(t *testing.T) {
 		},
 	}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	// Should find this exact pattern in the generated XML
 	expectedPattern := `<rule ref="category/pom/errorprone.xml/InvalidDependencyTypes"/>`
@@ -292,7 +292,7 @@ func TestNonEmptyParameterValue(t *testing.T) {
 		},
 	}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)
@@ -338,7 +338,7 @@ func TestExactJsonStructure(t *testing.T) {
 		},
 	}
 
-	obtainedConfig := CreatePmdConfig(config)
+	obtainedConfig := CreatePmd6Config(config)
 
 	var ruleset PMDRuleset
 	err := xml.Unmarshal([]byte(obtainedConfig), &ruleset)

--- a/tools/pmdRunner.go
+++ b/tools/pmdRunner.go
@@ -28,10 +28,26 @@ import (
 func RunPmd(repositoryToAnalyseDirectory string, pmdBinary string, pathsToCheck []string, outputFile string, outputFormat string, config config.ConfigType) error {
 	var cmd *exec.Cmd
 
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command(pmdBinary) // On Windows, don't add "pmd" subcommand
+	// Get tool info to check version
+	toolInfo := config.Tools()["pmd"]
+	if toolInfo == nil {
+		logger.Warn("PMD tool info not found in configuration")
+		return fmt.Errorf("pmd tool info not found in configuration")
+	}
+
+	// Check if we're using a newer version (7.0.0+)
+	isNewVersion := toolInfo.Version >= "7.0.0"
+
+	if isNewVersion {
+		// For newer versions (7.0.0+), use the binary with 'check' command
+		cmd = exec.Command(pmdBinary, "check", "--no-fail-on-violation")
 	} else {
-		cmd = exec.Command(pmdBinary, "pmd") // On Unix, use "pmd" subcommand
+		// For older versions, use "pmd" subcommand
+		if runtime.GOOS == "windows" {
+			cmd = exec.Command(pmdBinary) // On Windows, don't add "pmd" subcommand
+		} else {
+			cmd = exec.Command(pmdBinary, "pmd") // On Unix, use "pmd" subcommand
+		}
 	}
 
 	// Add config file from tools-configs directory if it exists
@@ -62,76 +78,69 @@ func RunPmd(repositoryToAnalyseDirectory string, pmdBinary string, pathsToCheck 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
-	// Get tool info to access environment variables
-	toolInfo := config.Tools()["pmd"]
-	if toolInfo != nil {
-		// Get Java runtime info
-		javaRuntime := config.Runtimes()["java"]
-		if javaRuntime != nil {
-			logger.Debug("Setting up Java environment", logrus.Fields{
-				"javaHome": javaRuntime.InstallDir,
+	// Get Java runtime info
+	javaRuntime := config.Runtimes()["java"]
+	if javaRuntime != nil {
+		logger.Debug("Setting up Java environment", logrus.Fields{
+			"javaHome": javaRuntime.InstallDir,
+		})
+
+		// Get current environment
+		env := os.Environ()
+
+		// Set JAVA_HOME to Java runtime install directory
+		javaHome := fmt.Sprintf("JAVA_HOME=%s", javaRuntime.InstallDir)
+		env = append(env, javaHome)
+
+		// Get Java binary path from runtime configuration
+		javaBinary := javaRuntime.Binaries["java"]
+		javaBinDir := filepath.Dir(javaBinary)
+
+		// Check if Java binary exists
+		if _, err := os.Stat(javaBinary); err != nil {
+			logger.Error("Java binary not found", logrus.Fields{
+				"expectedPath": javaBinary,
+				"error":        err,
 			})
 
-			// Get current environment
-			env := os.Environ()
+			// Not throwing - Fallback to the default Java runtime
+			// This fallback going to be removed in the future https://codacy.atlassian.net/browse/PLUTO-1421
+			fmt.Printf("⚠️ Warning: Java binary not found at %s: %v\n", javaBinary, err)
+			fmt.Println("⚠️ Trying to continue with the default Java runtime")
+			logger.Warn("Java binary not found. Continuing with the default Java runtime", logrus.Fields{
+				"expectedPath": javaBinary,
+				"error":        err,
+			})
+		} else {
+			// When java binary is found, we need to add it to the PATH
 
-			// Set JAVA_HOME to Java runtime install directory
-			javaHome := fmt.Sprintf("JAVA_HOME=%s", javaRuntime.InstallDir)
-			env = append(env, javaHome)
+			// Get current PATH
+			pathEnv := os.Getenv("PATH")
 
-			// Get Java binary path from runtime configuration
-			javaBinary := javaRuntime.Binaries["java"]
-			javaBinDir := filepath.Dir(javaBinary)
-
-			// Check if Java binary exists
-			if _, err := os.Stat(javaBinary); err != nil {
-				logger.Error("Java binary not found", logrus.Fields{
-					"expectedPath": javaBinary,
-					"error":        err,
-				})
-
-				// Not throwing - Fallback to the default Java runtime
-				// This fallback going to be removed in the future https://codacy.atlassian.net/browse/PLUTO-1421
-				fmt.Printf("⚠️ Warning: Java binary not found at %s: %v\n", javaBinary, err)
-				fmt.Println("⚠️ Trying to continue with the default Java runtime")
-				logger.Warn("Java binary not found. Continuing with the default Java runtime", logrus.Fields{
-					"expectedPath": javaBinary,
-					"error":        err,
-				})
-			} else {
-				// When java binary is found, we need to add it to the PATH
-
-				// Get current PATH
-				pathEnv := os.Getenv("PATH")
-
-				// On Windows, use semicolon as path separator
-				pathSeparator := ":"
-				if runtime.GOOS == "windows" {
-					pathSeparator = ";"
-				}
-
-				// Add Java bin directory to the beginning of PATH
-				newPath := fmt.Sprintf("PATH=%s%s%s", javaBinDir, pathSeparator, pathEnv)
-				env = append(env, newPath)
-
-				logger.Debug("Updated environment variables", logrus.Fields{
-					"javaHome":   javaHome,
-					"path":       newPath,
-					"binDir":     javaBinDir,
-					"javaBinary": javaBinary,
-				})
-
-				// Set the environment for the command
-				cmd.Env = env
+			// On Windows, use semicolon as path separator
+			pathSeparator := ":"
+			if runtime.GOOS == "windows" {
+				pathSeparator = ";"
 			}
 
-		} else {
-			logger.Warn("Java runtime not found in configuration")
-			return fmt.Errorf("java runtime not found in configuration")
+			// Add Java bin directory to the beginning of PATH
+			newPath := fmt.Sprintf("PATH=%s%s%s", javaBinDir, pathSeparator, pathEnv)
+			env = append(env, newPath)
+
+			logger.Debug("Updated environment variables", logrus.Fields{
+				"javaHome":   javaHome,
+				"path":       newPath,
+				"binDir":     javaBinDir,
+				"javaBinary": javaBinary,
+			})
+
+			// Set the environment for the command
+			cmd.Env = env
 		}
+
 	} else {
-		logger.Warn("PMD tool info not found in configuration")
-		return fmt.Errorf("pmd tool info not found in configuration")
+		logger.Warn("Java runtime not found in configuration")
+		return fmt.Errorf("java runtime not found in configuration")
 	}
 
 	logger.Debug("Running PMD command", logrus.Fields{


### PR DESCRIPTION
example init: 

```
⚠️  Multiple versions of 'pmd' detected: [6.55.0, 7.11.0], keeping 7.11.0
⚠️  Multiple versions of 'eslint' detected: [9.26.0, 8.57.0], keeping 9.26.0
Created languages configuration file based on enabled tools
PMD7 configuration created based on Codacy settings
ESLint configuration created based on Codacy settings. Ignoring plugin rules. ESLint plugins are not supported yet.

```