### PR TITLE
Fix/file logger location

### DIFF
--- a/tools/lizard/lizardRunner.go
+++ b/tools/lizard/lizardRunner.go
@@ -17,7 +17,7 @@ func RunLizard(workDirectory string, binary string, files []string, outputFile s
 	}
 
 	// Construct base command with lizard module
-	args := []string{"-m", "lizard", "-V"}
+	args := []string{"-m", "lizard", "--warnings_only"}
 
 	// Add files to analyze - if no files specified, analyze current directory
 	if len(files) > 0 {

--- a/tools/lizard/lizardRunner.go
+++ b/tools/lizard/lizardRunner.go
@@ -17,7 +17,7 @@ func RunLizard(workDirectory string, binary string, files []string, outputFile s
 	}
 
 	// Construct base command with lizard module
-	args := []string{"-m", "lizard", "--warnings_only"}
+	args := []string{"-m", "lizard", "-V"}
 
 	// Add files to analyze - if no files specified, analyze current directory
 	if len(files) > 0 {

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -94,17 +94,7 @@ func Log(level logrus.Level, msg string, fields logrus.Fields) {
 		// Get caller information
 		_, file, line, ok := runtime.Caller(2)
 		if ok {
-			// Clean up any path containing codacy-cli-v2 and remove parent directory references
-			file = filepath.Clean(file)
-			parts := strings.Split(file, string(filepath.Separator))
-			for i, part := range parts {
-				if strings.Contains(part, "codacy-cli-v2") {
-					if i+1 < len(parts) {
-						file = filepath.Join(parts[i+1:]...)
-					}
-					break
-				}
-			}
+			file = cleanupFilePath(file)
 			if fields == nil {
 				fields = logrus.Fields{}
 			}
@@ -149,4 +139,19 @@ func Warn(msg string, fields ...logrus.Fields) {
 		f = fields[0]
 	}
 	Log(logrus.WarnLevel, msg, f)
+}
+
+// cleanupFilePath removes codacy-cli-v2 and parent directory references from the file path
+func cleanupFilePath(file string) string {
+	file = filepath.Clean(file)
+	parts := strings.Split(file, string(filepath.Separator))
+	for i, part := range parts {
+		if strings.Contains(part, "codacy-cli-v2") {
+			if i+1 < len(parts) {
+				return filepath.Join(parts[i+1:]...)
+			}
+			break
+		}
+	}
+	return file
 }

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -94,9 +94,15 @@ func Log(level logrus.Level, msg string, fields logrus.Fields) {
 		// Get caller information
 		_, file, line, ok := runtime.Caller(2)
 		if ok {
-			if workspaceRoot, err := filepath.Abs("."); err == nil {
-				if rel, err := filepath.Rel(workspaceRoot, file); err == nil {
-					file = rel
+			// Clean up any path containing codacy-cli-v2 and remove parent directory references
+			file = filepath.Clean(file)
+			parts := strings.Split(file, string(filepath.Separator))
+			for i, part := range parts {
+				if strings.Contains(part, "codacy-cli-v2") {
+					if i+1 < len(parts) {
+						file = filepath.Join(parts[i+1:]...)
+					}
+					break
 				}
 			}
 			if fields == nil {


### PR DESCRIPTION
refactor: simplify log file paths by removing codacy-cli-v2 prefix

Modify logger path handling to:
- Remove any codacy-cli-v2 prefix from log file paths
- Strip out parent directory references (../)
- Clean up absolute paths to show only project-relative paths
- Handle various path formats including CI environment paths

Example transformations:
../codacy-cli-v2/cmd/install.go → cmd/install.go
../../home/runner/work/codacy-cli-v2/codacy-cli-v2/cmd/root.go → cmd/root.go