### PR TITLE
Feature: config discover command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Bootstraps the CLI configuration in your project's folder. This command creates 
 - `--organization` (string): Organization name, required with `--api-token`
 - `--repository` (string): Repository name, required with `--api-token`
 
+### `config discover` — Discover Project Languages
+
+Scans a project directory to detect programming languages and automatically configures appropriate static analysis tools. This command updates both `languages-config.yaml` and `codacy.yaml` with relevant tools for detected languages.
+
+```bash
+# Discover languages in current directory
+codacy-cli config discover .
+
+# Discover languages in specific project path
+codacy-cli config discover /path/to/project
+```
+
+**Features:**
+- Automatically detects file extensions and maps them to programming languages
+- Updates `.codacy/tools-configs/languages-config.yaml` with discovered languages
+- Enables relevant tools in `codacy.yaml` based on detected languages
+- Creates tool-specific configuration files for discovered tools
+- Works in both local and cloud modes
+
 ### `install` — Install Runtimes and Tools
 
 Installs all runtimes and tools specified in `.codacy/codacy.yaml`:
@@ -172,14 +191,17 @@ codacy-cli init
 # or
 codacy-cli init --api-token <token> --provider gh --organization my-org --repository my-repo
 
-# 2. Install all required runtimes and tools
+# 2. (Optional) Discover languages and configure tools automatically
+codacy-cli config discover .
+
+# 3. Install all required runtimes and tools
 codacy-cli install
 
-# 3. Run analysis (all tools or specific tool)
+# 4. Run analysis (all tools or specific tool)
 codacy-cli analyze
 codacy-cli analyze --tool eslint
 
-# 4. Upload results to Codacy
+# 5. Upload results to Codacy
 codacy-cli upload -s eslint.sarif -c <commit-uuid> -t <project-token>
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ Bootstraps the CLI configuration in your project's folder. This command creates 
 - `--organization` (string): Organization name, required with `--api-token`
 - `--repository` (string): Repository name, required with `--api-token`
 
+### `config reset` — Reset Configuration
+
+Resets the Codacy configuration files and tool-specific configurations. This command overwrites existing configuration with either local default configurations or repository-specific configurations from Codacy.
+
+```bash
+# Reset to local default configurations
+codacy-cli config reset
+
+# Reset to repository-specific configurations from Codacy
+codacy-cli config reset --api-token <token> --provider <gh|gl|bb> --organization <org> --repository <repo>
+```
+
+**Behavior:**
+- **Local mode**: Creates default configurations for all available tools
+- **Remote mode**: Fetches and applies repository-specific configurations from Codacy
+- Prevents accidental mode switching (remote to local requires explicit flags)
+- Overwrites existing `.codacy/codacy.yaml` and tool configurations
+- Creates or updates `.codacy/.gitignore` file
+
+**Flags:** Same as `init` command (api-token, provider, organization, repository)
+
 ### `config discover` — Discover Project Languages
 
 Scans a project directory to detect programming languages and automatically configures appropriate static analysis tools. This command updates both `languages-config.yaml` and `codacy.yaml` with relevant tools for detected languages.

--- a/cli-v2.go
+++ b/cli-v2.go
@@ -39,10 +39,13 @@ func main() {
 		}
 	}
 
-	// Check if command is init/update
-	if len(os.Args) > 1 && (os.Args[1] == "init" || os.Args[1] == "update") {
-		cmd.Execute()
-		return
+	// Check if command is init/update/version/help - these don't require configuration
+	if len(os.Args) > 1 {
+		cmdName := os.Args[1]
+		if cmdName == "init" || cmdName == "update" || cmdName == "version" || cmdName == "help" {
+			cmd.Execute()
+			return
+		}
 	}
 
 	// All other commands require a configuration file

--- a/cmd/cmdutils/flags.go
+++ b/cmd/cmdutils/flags.go
@@ -1,0 +1,16 @@
+package cmdutils
+
+import (
+	"codacy/cli-v2/domain"
+
+	"github.com/spf13/cobra"
+)
+
+// AddCloudFlags adds the common cloud-related flags to a cobra command.
+// The flags will be bound to the provided flags struct.
+func AddCloudFlags(cmd *cobra.Command, flags *domain.InitFlags) {
+	cmd.Flags().StringVar(&flags.ApiToken, "api-token", "", "Optional Codacy API token. If defined, configurations will be fetched from Codacy")
+	cmd.Flags().StringVar(&flags.Provider, "provider", "", "Provider (e.g., gh, bb, gl) to fetch configurations from Codacy. Required when api-token is provided")
+	cmd.Flags().StringVar(&flags.Organization, "organization", "", "Remote organization name to fetch configurations from Codacy. Required when api-token is provided")
+	cmd.Flags().StringVar(&flags.Repository, "repository", "", "Remote repository name to fetch configurations from Codacy. Required when api-token is provided")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,13 +4,22 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
 
 	"codacy/cli-v2/cmd/configsetup"
+	codacyclient "codacy/cli-v2/codacy-client"
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/domain"
+	"codacy/cli-v2/plugins"
 	"codacy/cli-v2/utils"
+	"codacy/cli-v2/utils/logger"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // configResetInitFlags holds the flags for the config reset command.
@@ -133,6 +142,483 @@ func runConfigResetLogic(cmd *cobra.Command, args []string, flags domain.InitFla
 	fmt.Println("  1. Run 'codacy-cli install' to install all dependencies based on the new/updated configuration.")
 	fmt.Println("  2. Run 'codacy-cli analyze' to start analyzing your code.")
 	fmt.Println()
+}
+
+// Placeholder for the path argument for discover command
+var discoverPath string
+
+var configDiscoverCmd = &cobra.Command{
+	Use:   "discover <path>",
+	Short: "Discover project languages and update tool configurations",
+	Long: "Scans the specified path to detect programming languages. " +
+		"Updates .codacy/tools-configs/languages-config.yaml with discovered languages " +
+		"and enables relevant tools in codacy.yaml. " +
+		"This command does not change existing tool versions or run installations. " +
+		"In Cloud mode, tools are only added if enabled in the cloud for the repository.",
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		discoverPath = args[0]
+
+		// Check if path exists
+		if _, err := os.Stat(discoverPath); os.IsNotExist(err) {
+			log.Fatalf("Error: Path %s does not exist", discoverPath)
+		}
+
+		fmt.Printf("Discovering languages and tools for path: %s\n", discoverPath)
+
+		// Detect file extensions first
+		extCount, err := detectFileExtensions(discoverPath)
+		if err != nil {
+			log.Fatalf("Error detecting file extensions: %v", err)
+		}
+
+		defaultToolLangMap := tools.GetDefaultToolLanguageMapping()
+
+		if len(extCount) > 0 {
+			recognizedExts := getRecognizableExtensions(extCount, defaultToolLangMap)
+			if len(recognizedExts) > 0 {
+				logger.Debug("Detected recognizable file extensions", logrus.Fields{
+					"extensions": recognizedExts,
+					"path":       discoverPath,
+				})
+			}
+		}
+
+		detectedLanguages, err := detectLanguagesInPath(discoverPath, defaultToolLangMap)
+		if err != nil {
+			log.Fatalf("Error detecting languages: %v", err)
+		}
+		if len(detectedLanguages) == 0 {
+			fmt.Println("No known languages detected in the provided path.")
+			return
+		}
+		logger.Debug("Detected languages in path", logrus.Fields{
+			"languages": getSortedKeys(detectedLanguages),
+			"path":      discoverPath,
+		})
+
+		toolsConfigDir := config.Config.ToolsConfigsDirectory()
+		if err := updateLanguagesConfig(detectedLanguages, toolsConfigDir, defaultToolLangMap); err != nil {
+			log.Fatalf("Error updating .codacy/tools-configs/languages-config.yaml: %v", err)
+		}
+		fmt.Println("Updated .codacy/tools-configs/languages-config.yaml")
+
+		// For updating codacy.yaml, we need to know the current CLI mode and potentially API creds
+		currentCliMode, err := config.Config.GetCliMode()
+		if err != nil {
+			log.Printf("Warning: Could not determine CLI mode: %v. Assuming local mode for tool enablement.", err)
+			currentCliMode = "local" // Default to local
+		}
+
+		codacyYAMLPath := config.Config.ProjectConfigFile()
+		if err := updateCodacyYAML(detectedLanguages, codacyYAMLPath, defaultToolLangMap, configResetInitFlags, currentCliMode); err != nil {
+			if strings.Contains(err.Error(), "❌ Fatal:") {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			log.Fatalf("Error updating %s: %v", codacyYAMLPath, err)
+		}
+		fmt.Printf("Updated %s with relevant tools.\n", filepath.Base(codacyYAMLPath))
+
+		fmt.Println("\n✅ Successfully discovered languages and updated configurations.")
+		fmt.Println("   Please review the changes in '.codacy/codacy.yaml' and '.codacy/tools-configs/languages-config.yaml'.")
+	},
+}
+
+func getSortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// detectLanguagesInPath detects languages based on file extensions found in the path.
+func detectLanguagesInPath(rootPath string, toolLangMap map[string]domain.ToolLanguageInfo) (map[string]struct{}, error) {
+	detectedLangs := make(map[string]struct{})
+	extToLang := make(map[string][]string)
+
+	// Build extension to language mapping
+	for _, toolInfo := range toolLangMap {
+		for _, lang := range toolInfo.Languages {
+			if lang == "Multiple" || lang == "Generic" { // Skip generic language types for direct detection
+				continue
+			}
+			for _, ext := range toolInfo.Extensions {
+				extToLang[ext] = append(extToLang[ext], lang)
+			}
+		}
+	}
+
+	// Get file extensions from the path
+	extCount, err := detectFileExtensions(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect file extensions in path %s: %w", rootPath, err)
+	}
+
+	// Map extensions to languages
+	for ext := range extCount {
+		if langs, ok := extToLang[ext]; ok {
+			for _, lang := range langs {
+				detectedLangs[lang] = struct{}{}
+			}
+		}
+	}
+
+	return detectedLangs, nil
+}
+
+// updateLanguagesConfig updates the .codacy/tools-configs/languages-config.yaml file.
+func updateLanguagesConfig(detectedLanguages map[string]struct{}, toolsConfigDir string, defaultToolLangMap map[string]domain.ToolLanguageInfo) error {
+	langConfigPath := filepath.Join(toolsConfigDir, "languages-config.yaml")
+	var langConf domain.LanguagesConfig
+
+	if _, err := os.Stat(langConfigPath); err == nil {
+		data, err := os.ReadFile(langConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing languages-config.yaml: %w", err)
+		}
+		if err := yaml.Unmarshal(data, &langConf); err != nil {
+			return fmt.Errorf("failed to parse existing languages-config.yaml: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat languages-config.yaml: %w", err)
+	}
+
+	// Create a map of existing tools for easier update
+	existingToolsMap := make(map[string]*domain.ToolLanguageInfo)
+	for i := range langConf.Tools {
+		existingToolsMap[langConf.Tools[i].Name] = &langConf.Tools[i]
+	}
+
+	for toolName, toolInfoFromDefaults := range defaultToolLangMap {
+		isRelevantTool := false
+		relevantLangsForThisTool := []string{}
+		relevantExtsForThisToolMap := make(map[string]struct{})
+
+		for _, langDefault := range toolInfoFromDefaults.Languages {
+			if _, isDetected := detectedLanguages[langDefault]; isDetected {
+				isRelevantTool = true
+				if !slices.Contains(relevantLangsForThisTool, langDefault) {
+					relevantLangsForThisTool = append(relevantLangsForThisTool, langDefault)
+				}
+				// Add extensions associated with this detected language for this tool
+				for _, defaultExt := range toolInfoFromDefaults.Extensions {
+					// A simple heuristic: if a tool supports a language, and that language is detected,
+					// all default extensions of that tool for that language group are considered relevant.
+					// This assumes toolInfoFromDefaults.Extensions are relevant for all toolInfoFromDefaults.Languages.
+					// A more precise mapping might be needed if a tool's extensions vary significantly per language it supports.
+					relevantExtsForThisToolMap[defaultExt] = struct{}{}
+				}
+			}
+		}
+
+		if isRelevantTool {
+			relevantExtsForThisTool := getSortedKeys(relevantExtsForThisToolMap)
+			sort.Strings(relevantLangsForThisTool)
+
+			if existingEntry, ok := existingToolsMap[toolName]; ok {
+				// Merge languages and extensions, keeping them unique and sorted
+				existingLangsSet := make(map[string]struct{})
+				for _, lang := range existingEntry.Languages {
+					existingLangsSet[lang] = struct{}{}
+				}
+				for _, lang := range relevantLangsForThisTool {
+					existingLangsSet[lang] = struct{}{}
+				}
+				existingEntry.Languages = getSortedKeys(existingLangsSet)
+
+				existingExtsSet := make(map[string]struct{})
+				for _, ext := range existingEntry.Extensions {
+					existingExtsSet[ext] = struct{}{}
+				}
+				for _, ext := range relevantExtsForThisTool {
+					existingExtsSet[ext] = struct{}{}
+				}
+				existingEntry.Extensions = getSortedKeys(existingExtsSet)
+
+			} else {
+				newEntry := domain.ToolLanguageInfo{
+					Name:       toolName,
+					Languages:  relevantLangsForThisTool,
+					Extensions: relevantExtsForThisTool,
+				}
+				langConf.Tools = append(langConf.Tools, newEntry)
+				existingToolsMap[toolName] = &langConf.Tools[len(langConf.Tools)-1] // update map with pointer to new entry
+			}
+		}
+	}
+
+	// Sort tools by name for consistent output
+	sort.SliceStable(langConf.Tools, func(i, j int) bool {
+		return langConf.Tools[i].Name < langConf.Tools[j].Name
+	})
+
+	data, err := yaml.Marshal(langConf)
+	if err != nil {
+		return fmt.Errorf("failed to marshal languages-config.yaml: %w", err)
+	}
+	if err := os.MkdirAll(toolsConfigDir, utils.DefaultDirPerms); err != nil {
+		return fmt.Errorf("failed to create tools-configs directory: %w", err)
+	}
+	return os.WriteFile(langConfigPath, data, utils.DefaultFilePerms)
+}
+
+// updateCodacyYAML updates the codacy.yaml file with newly relevant tools.
+func updateCodacyYAML(detectedLanguages map[string]struct{}, codacyYAMLPath string, defaultToolLangMap map[string]domain.ToolLanguageInfo, initFlags domain.InitFlags, cliMode string) error {
+	var configData map[string]interface{}
+
+	if _, err := os.Stat(codacyYAMLPath); err == nil {
+		content, err := os.ReadFile(codacyYAMLPath)
+		if err != nil {
+			return fmt.Errorf("error reading %s: %w", codacyYAMLPath, err)
+		}
+		if err := yaml.Unmarshal(content, &configData); err != nil {
+			if strings.Contains(err.Error(), "cannot unmarshal") {
+				return fmt.Errorf(
+					"❌ Fatal: %s contains invalid configuration - run 'codacy-cli config reset' to fix: %v",
+					filepath.Base(codacyYAMLPath), err)
+			}
+			return fmt.Errorf(
+				"❌ Fatal: %s is broken or has invalid YAML format - run 'codacy-cli config reset' to reinitialize your configuration",
+				filepath.Base(codacyYAMLPath))
+		}
+	} else if os.IsNotExist(err) {
+		return fmt.Errorf("codacy.yaml file not found")
+	} else {
+		return fmt.Errorf("error accessing %s: %w", codacyYAMLPath, err)
+	}
+
+	toolsRaw, _ := configData["tools"].([]interface{})
+	currentToolsList := []string{}
+	currentToolSetByName := make(map[string]string)        // "eslint" -> "eslint@version"
+	currentToolSetWithVersion := make(map[string]struct{}) // "eslint@version" -> {}
+
+	for _, t := range toolsRaw {
+		if toolStr, ok := t.(string); ok {
+			currentToolsList = append(currentToolsList, toolStr)
+			currentToolSetWithVersion[toolStr] = struct{}{}
+			parts := strings.Split(toolStr, "@")
+			if len(parts) > 0 {
+				currentToolSetByName[parts[0]] = toolStr
+			}
+		}
+	}
+
+	candidateToolsToAdd := make(map[string]struct{}) // tool names like "eslint"
+	for toolName, toolInfo := range defaultToolLangMap {
+		for _, lang := range toolInfo.Languages {
+			if _, detected := detectedLanguages[lang]; detected {
+				candidateToolsToAdd[toolName] = struct{}{}
+				break
+			}
+		}
+	}
+
+	if cliMode == "remote" && initFlags.ApiToken != "" {
+		fmt.Println("Cloud mode: Verifying tools against repository settings...")
+		cloudTools, err := codacyclient.GetRepositoryTools(initFlags)
+		if err != nil {
+			return fmt.Errorf("failed to get repository tools from cloud: %w", err)
+		}
+		cloudEnabledToolNames := make(map[string]bool)
+		for _, ct := range cloudTools {
+			// Assuming ct.Name or similar field exists that matches our short tool names.
+			// The domain.Tool from GetRepositoryTools usually has a UUID, we need to map it.
+			// For now, we'll use a helper or assume names match if direct mapping isn't straightforward.
+			// This might need adjustment based on how GetRepositoryTools returns tool identifiers.
+			// Let's assume tool.Name from domain.Tool is the short name (e.g., "eslint").
+			// This requires checking the actual structure returned by GetRepositoryTools.
+			// For now, we'll use a placeholder map from UUID to short name, or simply compare by name.
+			// domain.SupportedToolsMetadata maps UUID to name.
+
+			var toolShortName string
+			for uuid, meta := range domain.SupportedToolsMetadata {
+				if uuid == ct.Uuid { // ct.Uuid is the correct field from domain.Tool
+					toolShortName = meta.Name
+					break
+				}
+			}
+
+			if toolShortName != "" && ct.Settings.Enabled {
+				cloudEnabledToolNames[toolShortName] = true
+			}
+
+		}
+
+		filteredCandidates := make(map[string]struct{})
+		for toolName := range candidateToolsToAdd {
+			if _, isEnabledInCloud := cloudEnabledToolNames[toolName]; isEnabledInCloud {
+				filteredCandidates[toolName] = struct{}{}
+			} else {
+				fmt.Printf("Tool %s detected locally but not enabled in cloud, skipping addition to codacy.yaml.\n", toolName)
+			}
+		}
+		candidateToolsToAdd = filteredCandidates
+	}
+
+	defaultToolVersions := plugins.GetToolVersions()
+	finalToolsList := currentToolsList // Start with existing tools
+
+	addedNewTool := false
+	for toolNameToAdd := range candidateToolsToAdd {
+		if _, alreadyConfigured := currentToolSetByName[toolNameToAdd]; !alreadyConfigured {
+			version, ok := defaultToolVersions[toolNameToAdd]
+			if !ok {
+				log.Printf("Warning: No default version found for tool %s. Skipping.", toolNameToAdd)
+				continue
+			}
+			newToolEntry := toolNameToAdd + "@" + version
+			if _, entryExists := currentToolSetWithVersion[newToolEntry]; !entryExists {
+				finalToolsList = append(finalToolsList, newToolEntry)
+				fmt.Printf("Adding tool to codacy.yaml: %s\n", newToolEntry)
+				addedNewTool = true
+			}
+		}
+	}
+
+	// Sort the final list for consistency
+	sort.Strings(finalToolsList)
+	configData["tools"] = finalToolsList
+
+	// Update runtimes if new tools were added
+	if addedNewTool || len(currentToolsList) == 0 { // Also run if it's a new codacy.yaml
+		neededRuntimes := make(map[string]string) // runtimeName -> runtimeVersion
+		runtimeDependencies := plugins.GetToolRuntimeDependencies()
+		defaultRuntimeVersions := plugins.GetRuntimeVersions()
+
+		for _, toolEntry := range finalToolsList {
+			toolName := strings.Split(toolEntry, "@")[0]
+			if runtimeName, depends := runtimeDependencies[toolName]; depends {
+				if _, alreadyNeeded := neededRuntimes[runtimeName]; !alreadyNeeded {
+					if version, ok := defaultRuntimeVersions[runtimeName]; ok {
+						neededRuntimes[runtimeName] = version
+					} else {
+						log.Printf("Warning: No default version for runtime %s needed by %s", runtimeName, toolName)
+					}
+				}
+			}
+		}
+		// Add dart for dartanalyzer if not already covered by another dart-needing tool
+		hasDartAnalyzer := false
+		for _, toolEntry := range finalToolsList {
+			if strings.HasPrefix(toolEntry, "dartanalyzer@") {
+				hasDartAnalyzer = true
+				break
+			}
+		}
+		if hasDartAnalyzer {
+			if _, dartNeeded := neededRuntimes["dart"]; !dartNeeded {
+				if _, flutterNeeded := neededRuntimes["flutter"]; !flutterNeeded { // Only add dart if flutter isn't already there
+					if dartVersion, ok := defaultRuntimeVersions["dart"]; ok {
+						neededRuntimes["dart"] = dartVersion
+					}
+				}
+			}
+		}
+
+		// Preserve existing runtimes and their versions if possible, only add new ones.
+		// Or, simpler: recalculate all needed runtimes based on finalToolsList.
+		// The current configsetup.ConfigFileTemplate recalculates runtimes.
+		// For discover, we should be less destructive.
+		// Let's try to merge:
+		existingRuntimesRaw, _ := configData["runtimes"].([]interface{})
+		finalRuntimesList := []string{}
+		existingRuntimeSet := make(map[string]string) // name -> name@version
+
+		for _, r := range existingRuntimesRaw {
+			if rtStr, ok := r.(string); ok {
+				finalRuntimesList = append(finalRuntimesList, rtStr)
+				name := strings.Split(rtStr, "@")[0]
+				existingRuntimeSet[name] = rtStr
+			}
+		}
+
+		for rtName, rtVersion := range neededRuntimes {
+			if _, exists := existingRuntimeSet[rtName]; !exists {
+				finalRuntimesList = append(finalRuntimesList, rtName+"@"+rtVersion)
+				fmt.Printf("Adding runtime to codacy.yaml: %s@%s\n", rtName, rtVersion)
+			}
+			// We are not updating versions of existing runtimes here, just adding new ones.
+		}
+		sort.Strings(finalRuntimesList)
+		configData["runtimes"] = finalRuntimesList
+	}
+
+	yamlData, err := yaml.Marshal(configData)
+	if err != nil {
+		return fmt.Errorf("error marshaling %s: %w", codacyYAMLPath, err)
+	}
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(codacyYAMLPath), utils.DefaultDirPerms); err != nil {
+		return fmt.Errorf("error creating .codacy directory: %w", err)
+	}
+	return os.WriteFile(codacyYAMLPath, yamlData, utils.DefaultFilePerms)
+}
+
+// detectFileExtensions walks the directory and collects all unique file extensions with their counts
+func detectFileExtensions(rootPath string) (map[string]int, error) {
+	extCount := make(map[string]int)
+
+	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != "" {
+				extCount[ext]++
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk path %s: %w", rootPath, err)
+	}
+
+	return extCount, nil
+}
+
+// getRecognizableExtensions returns a sorted list of extensions that are mapped to languages
+func getRecognizableExtensions(extCount map[string]int, toolLangMap map[string]domain.ToolLanguageInfo) []string {
+	// Build set of recognized extensions
+	recognizedExts := make(map[string]struct{})
+	for _, toolInfo := range toolLangMap {
+		for _, ext := range toolInfo.Extensions {
+			recognizedExts[ext] = struct{}{}
+		}
+	}
+
+	// Filter and format recognized extensions with counts
+	type extInfo struct {
+		ext   string
+		count int
+	}
+	var recognizedExtList []extInfo
+
+	for ext, count := range extCount {
+		if _, ok := recognizedExts[ext]; ok {
+			recognizedExtList = append(recognizedExtList, extInfo{ext, count})
+		}
+	}
+
+	// Sort by count (descending) and then by extension name
+	sort.Slice(recognizedExtList, func(i, j int) bool {
+		if recognizedExtList[i].count != recognizedExtList[j].count {
+			return recognizedExtList[i].count > recognizedExtList[j].count
+		}
+		return recognizedExtList[i].ext < recognizedExtList[j].ext
+	})
+
+	// Format extensions with their counts
+	result := make([]string, len(recognizedExtList))
+	for i, info := range recognizedExtList {
+		result[i] = fmt.Sprintf("%s (%d files)", info.ext, info.count)
+	}
+
+	return result
 }
 
 func init() {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,6 +15,7 @@ import (
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/domain"
 	"codacy/cli-v2/plugins"
+	"codacy/cli-v2/tools"
 	"codacy/cli-v2/utils"
 	"codacy/cli-v2/utils/logger"
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -341,25 +341,14 @@ func updateLanguagesConfig(detectedLanguages map[string]struct{}, toolsConfigDir
 func updateCodacyYAML(detectedLanguages map[string]struct{}, codacyYAMLPath string, defaultToolLangMap map[string]domain.ToolLanguageInfo, initFlags domain.InitFlags, cliMode string) error {
 	var configData map[string]interface{}
 
-	if _, err := os.Stat(codacyYAMLPath); err == nil {
-		content, err := os.ReadFile(codacyYAMLPath)
-		if err != nil {
-			return fmt.Errorf("error reading %s: %w", codacyYAMLPath, err)
-		}
-		if err := yaml.Unmarshal(content, &configData); err != nil {
-			if strings.Contains(err.Error(), "cannot unmarshal") {
-				return fmt.Errorf(
-					"❌ Fatal: %s contains invalid configuration - run 'codacy-cli config reset' to fix: %v",
-					filepath.Base(codacyYAMLPath), err)
-			}
-			return fmt.Errorf(
-				"❌ Fatal: %s is broken or has invalid YAML format - run 'codacy-cli config reset' to reinitialize your configuration",
-				filepath.Base(codacyYAMLPath))
-		}
-	} else if os.IsNotExist(err) {
-		return fmt.Errorf("codacy.yaml file not found")
-	} else {
-		return fmt.Errorf("error accessing %s: %w", codacyYAMLPath, err)
+	// Read and parse codacy.yaml (validation is done globally in PersistentPreRun)
+	content, err := os.ReadFile(codacyYAMLPath)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %w", codacyYAMLPath, err)
+	}
+
+	if err := yaml.Unmarshal(content, &configData); err != nil {
+		return fmt.Errorf("error parsing %s: %w", codacyYAMLPath, err)
 	}
 
 	toolsRaw, _ := configData["tools"].([]interface{})

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -217,8 +217,27 @@ var configDiscoverCmd = &cobra.Command{
 		}
 		fmt.Printf("Updated %s with relevant tools.\n", filepath.Base(codacyYAMLPath))
 
+		// Determine which tools are relevant for discovered languages and create their configurations
+		discoveredToolNames := make(map[string]struct{})
+		for toolName, toolInfo := range defaultToolLangMap {
+			for _, toolLang := range toolInfo.Languages {
+				if _, detected := detectedLanguages[toolLang]; detected {
+					discoveredToolNames[toolName] = struct{}{}
+					break
+				}
+			}
+		}
+
+		// Create tool configuration files for discovered tools
+		if len(discoveredToolNames) > 0 {
+			fmt.Printf("\nCreating tool configurations for discovered tools...\n")
+			if err := configsetup.CreateConfigurationFilesForDiscoveredTools(discoveredToolNames, toolsConfigDir, configResetInitFlags); err != nil {
+				log.Printf("Warning: Failed to create some tool configurations: %v", err)
+			}
+		}
+
 		fmt.Println("\n✅ Successfully discovered languages and updated configurations.")
-		fmt.Println("   Please review the changes in '.codacy/codacy.yaml' and '.codacy/tools-configs/languages-config.yaml'.")
+		fmt.Println("   Please review the changes in '.codacy/codacy.yaml' and '.codacy/tools-configs/' directory.")
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"codacy/cli-v2/cmd/cmdutils"
 	"codacy/cli-v2/cmd/configsetup"
 	"codacy/cli-v2/config"
 	"codacy/cli-v2/domain"
@@ -14,10 +15,8 @@ import (
 var initFlags domain.InitFlags
 
 func init() {
-	initCmd.Flags().StringVar(&initFlags.ApiToken, "api-token", "", "optional codacy api token, if defined configurations will be fetched from codacy")
-	initCmd.Flags().StringVar(&initFlags.Provider, "provider", "", "provider (gh/bb/gl) to fetch configurations from codacy, required when api-token is provided")
-	initCmd.Flags().StringVar(&initFlags.Organization, "organization", "", "remote organization name to fetch configurations from codacy, required when api-token is provided")
-	initCmd.Flags().StringVar(&initFlags.Repository, "repository", "", "remote repository name to fetch configurations from codacy, required when api-token is provided")
+	// Add cloud-related flags
+	cmdutils.AddCloudFlags(initCmd, &initFlags)
 	rootCmd.AddCommand(initCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,18 @@ var rootCmd = &cobra.Command{
 			"full_command": maskedArgs,
 			"args":         args,
 		})
+
+		// Validate codacy.yaml for all commands except init, help, and version
+		if !shouldSkipValidation(cmd.Name()) {
+			if err := validateCodacyYAML(); err != nil {
+				logger.Error("Global validation failed", logrus.Fields{
+					"command": cmd.Name(),
+					"error":   err.Error(),
+				})
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check if .codacy directory exists

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"codacy/cli-v2/config"
+	"codacy/cli-v2/utils/logger"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// validateCodacyYAML validates that codacy.yaml exists and is not empty
+// Returns an error if validation fails, nil if validation passes
+func validateCodacyYAML() error {
+	codacyYAMLPath := config.Config.ProjectConfigFile()
+
+	// Check if file exists
+	if _, err := os.Stat(codacyYAMLPath); os.IsNotExist(err) {
+		logger.Error("codacy.yaml file not found", logrus.Fields{
+			"file": codacyYAMLPath,
+		})
+		return fmt.Errorf("❌ Fatal: codacy.yaml file not found. Please run 'codacy-cli init' to initialize your configuration first")
+	} else if err != nil {
+		logger.Error("Error accessing codacy.yaml file", logrus.Fields{
+			"file":  codacyYAMLPath,
+			"error": err,
+		})
+		return fmt.Errorf("error accessing %s: %w", codacyYAMLPath, err)
+	}
+
+	// Read file content
+	content, err := os.ReadFile(codacyYAMLPath)
+	if err != nil {
+		logger.Error("Failed to read codacy.yaml file", logrus.Fields{
+			"file":  codacyYAMLPath,
+			"error": err,
+		})
+		return fmt.Errorf("error reading %s: %w", codacyYAMLPath, err)
+	}
+
+	// Check if file is empty or contains only whitespace
+	if len(strings.TrimSpace(string(content))) == 0 {
+		logger.Error("codacy.yaml file is empty", logrus.Fields{
+			"file": codacyYAMLPath,
+		})
+		return fmt.Errorf("❌ Fatal: %s is empty. Please run 'codacy-cli init' to initialize your configuration first", filepath.Base(codacyYAMLPath))
+	}
+
+	// Try to parse YAML to ensure it's valid
+	var configData map[string]interface{}
+	if err := yaml.Unmarshal(content, &configData); err != nil {
+		logger.Error("Failed to parse codacy.yaml file", logrus.Fields{
+			"file":  codacyYAMLPath,
+			"error": err,
+		})
+		if strings.Contains(err.Error(), "cannot unmarshal") {
+			return fmt.Errorf("❌ Fatal: %s contains invalid configuration - run 'codacy-cli config reset' to fix: %v", filepath.Base(codacyYAMLPath), err)
+		}
+		return fmt.Errorf("❌ Fatal: %s is broken or has invalid YAML format - run 'codacy-cli config reset' to reinitialize your configuration", filepath.Base(codacyYAMLPath))
+	}
+
+	// Ensure configData is not nil after unmarshaling
+	if configData == nil {
+		logger.Error("codacy.yaml unmarshaled to nil data", logrus.Fields{
+			"file": codacyYAMLPath,
+		})
+		return fmt.Errorf("❌ Fatal: %s contains no valid configuration. Please run 'codacy-cli init' to initialize your configuration first", filepath.Base(codacyYAMLPath))
+	}
+
+	return nil
+}
+
+// shouldSkipValidation checks if the current command should skip codacy.yaml validation
+func shouldSkipValidation(cmdName string) bool {
+	skipCommands := []string{
+		"init",
+		"help",
+		"version",
+		"reset",      // config reset should work even with empty/invalid codacy.yaml
+		"codacy-cli", // root command when called without subcommands
+	}
+
+	for _, skipCmd := range skipCommands {
+		if cmdName == skipCmd {
+			return true
+		}
+	}
+
+	return false
+}

--- a/config/detector.go
+++ b/config/detector.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"codacy/cli-v2/domain"
+	"codacy/cli-v2/utils/logger"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DetectFileExtensions walks the directory and collects all unique file extensions with their counts
+func DetectFileExtensions(rootPath string) (map[string]int, error) {
+	extCount := make(map[string]int)
+
+	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != "" {
+				extCount[ext]++
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk path %s: %w", rootPath, err)
+	}
+
+	return extCount, nil
+}
+
+// GetRecognizableExtensions returns a sorted list of extensions that are mapped to languages
+func GetRecognizableExtensions(extCount map[string]int, toolLangMap map[string]domain.ToolLanguageInfo) []string {
+	// Build set of recognized extensions
+	recognizedExts := make(map[string]struct{})
+	for _, toolInfo := range toolLangMap {
+		for _, ext := range toolInfo.Extensions {
+			recognizedExts[ext] = struct{}{}
+		}
+	}
+
+	// Filter and format recognized extensions with counts
+	type extInfo struct {
+		ext   string
+		count int
+	}
+	var recognizedExtList []extInfo
+
+	for ext, count := range extCount {
+		if _, ok := recognizedExts[ext]; ok {
+			recognizedExtList = append(recognizedExtList, extInfo{ext, count})
+		}
+	}
+
+	// Sort by count (descending) and then by extension name
+	sort.Slice(recognizedExtList, func(i, j int) bool {
+		if recognizedExtList[i].count != recognizedExtList[j].count {
+			return recognizedExtList[i].count > recognizedExtList[j].count
+		}
+		return recognizedExtList[i].ext < recognizedExtList[j].ext
+	})
+
+	// Format extensions with their counts
+	result := make([]string, len(recognizedExtList))
+	for i, info := range recognizedExtList {
+		result[i] = fmt.Sprintf("%s (%d files)", info.ext, info.count)
+	}
+
+	return result
+}
+
+// DetectLanguages detects languages based on file extensions found in the path
+func DetectLanguages(rootPath string, toolLangMap map[string]domain.ToolLanguageInfo) (map[string]struct{}, error) {
+	detectedLangs := make(map[string]struct{})
+	extToLang := make(map[string][]string)
+
+	// Build extension to language mapping
+	for _, toolInfo := range toolLangMap {
+		for _, lang := range toolInfo.Languages {
+			if lang == "Multiple" || lang == "Generic" { // Skip generic language types for direct detection
+				continue
+			}
+			for _, ext := range toolInfo.Extensions {
+				extToLang[ext] = append(extToLang[ext], lang)
+			}
+		}
+	}
+
+	// Get file extensions from the path
+	extCount, err := DetectFileExtensions(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect file extensions in path %s: %w", rootPath, err)
+	}
+
+	// Map only found extensions to languages
+	for ext := range extCount {
+		if langs, ok := extToLang[ext]; ok {
+			// Log which extensions map to which languages for debugging
+			logger.Debug("Found files with extension", logrus.Fields{
+				"extension": ext,
+				"count":     extCount[ext],
+				"languages": langs,
+			})
+			for _, lang := range langs {
+				detectedLangs[lang] = struct{}{}
+			}
+		}
+	}
+
+	// Log the final set of detected languages with their corresponding extensions
+	if len(detectedLangs) > 0 {
+		langToExts := make(map[string][]string)
+		for ext, count := range extCount {
+			if langs, ok := extToLang[ext]; ok {
+				for _, lang := range langs {
+					langToExts[lang] = append(langToExts[lang], fmt.Sprintf("%s (%d files)", ext, count))
+				}
+			}
+		}
+
+		logger.Debug("Detected languages in path", logrus.Fields{
+			"languages_with_files": langToExts,
+			"path":                 rootPath,
+		})
+	}
+
+	return detectedLangs, nil
+}
+
+// GetSortedKeys returns a sorted slice of strings from a string set
+func GetSortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/tools/language_config.go
+++ b/tools/language_config.go
@@ -15,7 +15,7 @@ import (
 )
 
 // defaultToolLanguageMap defines the default mapping of tools to their supported languages and file extensions
-var defaultToolLanguageMap = map[string]domain.ToolLanguageInfo{
+var DefaultToolLanguageMap = map[string]domain.ToolLanguageInfo{
 	"pylint": {
 		Name:       "pylint",
 		Languages:  []string{"Python"},
@@ -58,8 +58,17 @@ var defaultToolLanguageMap = map[string]domain.ToolLanguageInfo{
 	},
 }
 
+// GetDefaultToolLanguageMapping returns the default mapping of tools to their supported languages and file extensions
+func GetDefaultToolLanguageMapping() map[string]domain.ToolLanguageInfo {
+	return DefaultToolLanguageMap
+}
+
+// CreateLanguagesConfigFile creates languages-config.yaml based on API response
+func CreateLanguagesConfigFile(apiTools []domain.Tool, toolsConfigDir string, toolIDMap map[string]string, initFlags domain.InitFlags) error {
 	// Build a list of tool language info for enabled tools
 	var configTools []domain.ToolLanguageInfo
+
+	var toolLanguageMap = DefaultToolLanguageMap
 
 	repositoryLanguages, err := getRepositoryLanguages(initFlags)
 	if err != nil {

--- a/tools/language_config.go
+++ b/tools/language_config.go
@@ -14,51 +14,49 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// CreateLanguagesConfigFile creates languages-config.yaml based on API response
-func CreateLanguagesConfigFile(apiTools []domain.Tool, toolsConfigDir string, toolIDMap map[string]string, initFlags domain.InitFlags) error {
-	// Map tool names to their language/extension information
-	toolLanguageMap := map[string]domain.ToolLanguageInfo{
-		"cppcheck": {
-			Name:       "cppcheck",
-			Languages:  []string{"C", "CPP"},
-			Extensions: []string{".c", ".cpp", ".cc", ".h", ".hpp"},
-		},
-		"pylint": {
-			Name:       "pylint",
-			Languages:  []string{"Python"},
-			Extensions: []string{".py"},
-		},
-		"eslint": {
-			Name:       "eslint",
-			Languages:  []string{"JavaScript", "TypeScript", "JSX", "TSX"},
-			Extensions: []string{".js", ".jsx", ".ts", ".tsx"},
-		},
-		"pmd": {
-			Name:       "pmd",
-			Languages:  []string{"Java", "JavaScript", "JSP", "Velocity", "XML", "Apex", "Scala", "Ruby", "VisualForce"},
-			Extensions: []string{".java", ".js", ".jsp", ".vm", ".xml", ".cls", ".trigger", ".scala", ".rb", ".page", ".component"},
-		},
-		"trivy": {
-			Name:       "trivy",
-			Languages:  []string{"Multiple"},
-			Extensions: []string{},
-		},
-		"dartanalyzer": {
-			Name:       "dartanalyzer",
-			Languages:  []string{"Dart"},
-			Extensions: []string{".dart"},
-		},
-		"lizard": {
-			Name:       "lizard",
-			Languages:  []string{"C", "CPP", "Java", "C#", "JavaScript", "TypeScript", "VueJS", "Objective-C", "Swift", "Python", "Ruby", "TTCN-3", "PHP", "Scala", "GDScript", "Golang", "Lua", "Rust", "Fortran", "Kotlin", "Solidity", "Erlang", "Zig", "Perl"},
-			Extensions: []string{".c", ".cpp", ".cc", ".h", ".hpp", ".java", ".cs", ".js", ".jsx", ".ts", ".tsx", ".vue", ".m", ".swift", ".py", ".rb", ".ttcn", ".php", ".scala", ".gd", ".go", ".lua", ".rs", ".f", ".f90", ".kt", ".sol", ".erl", ".zig", ".pl"},
-		},
-		"semgrep": {
-			Name:       "semgrep",
-			Languages:  []string{"C", "CPP", "C#", "Generic", "Go", "Java", "JavaScript", "JSON", "Kotlin", "Python", "TypeScript", "Ruby", "Rust", "JSX", "PHP", "Scala", "Swift", "Terraform"},
-			Extensions: []string{".c", ".cpp", ".h", ".hpp", ".cs", ".go", ".java", ".js", ".json", ".kt", ".py", ".ts", ".rb", ".rs", ".jsx", ".php", ".scala", ".swift", ".tf", ".tfvars"},
-		},
-	}
+// defaultToolLanguageMap defines the default mapping of tools to their supported languages and file extensions
+var defaultToolLanguageMap = map[string]domain.ToolLanguageInfo{
+	"pylint": {
+		Name:       "pylint",
+		Languages:  []string{"Python"},
+		Extensions: []string{".py"},
+	},
+	"eslint": {
+		Name:       "eslint",
+		Languages:  []string{"JavaScript", "TypeScript", "JSX", "TSX"},
+		Extensions: []string{".js", ".jsx", ".ts", ".tsx"},
+	},
+	"pmd": {
+		Name:       "pmd",
+		Languages:  []string{"Java", "JavaScript", "JSP", "Velocity", "XML", "Apex", "Scala", "Ruby", "VisualForce"},
+		Extensions: []string{".java", ".js", ".jsp", ".vm", ".xml", ".cls", ".trigger", ".scala", ".rb", ".page", ".component"},
+	},
+	"trivy": {
+		Name:       "trivy",
+		Languages:  []string{"Multiple"},
+		Extensions: []string{},
+	},
+	"dartanalyzer": {
+		Name:       "dartanalyzer",
+		Languages:  []string{"Dart"},
+		Extensions: []string{".dart"},
+	},
+	"lizard": {
+		Name:       "lizard",
+		Languages:  []string{"C", "CPP", "Java", "C#", "JavaScript", "TypeScript", "VueJS", "Objective-C", "Swift", "Python", "Ruby", "TTCN-3", "PHP", "Scala", "GDScript", "Golang", "Lua", "Rust", "Fortran", "Kotlin", "Solidity", "Erlang", "Zig", "Perl"},
+		Extensions: []string{".c", ".cpp", ".cc", ".h", ".hpp", ".java", ".cs", ".js", ".jsx", ".ts", ".tsx", ".vue", ".m", ".swift", ".py", ".rb", ".ttcn", ".php", ".scala", ".gd", ".go", ".lua", ".rs", ".f", ".f90", ".kt", ".sol", ".erl", ".zig", ".pl"},
+	},
+	"semgrep": {
+		Name:       "semgrep",
+		Languages:  []string{"C", "CPP", "C#", "Generic", "Go", "Java", "JavaScript", "JSON", "Kotlin", "Python", "TypeScript", "Ruby", "Rust", "JSX", "PHP", "Scala", "Swift", "Terraform"},
+		Extensions: []string{".c", ".cpp", ".h", ".hpp", ".cs", ".go", ".java", ".js", ".json", ".kt", ".py", ".ts", ".rb", ".rs", ".jsx", ".php", ".scala", ".swift", ".tf", ".tfvars"},
+	},
+	"codacy-enigma-cli": {
+		Name:       "codacy-enigma-cli",
+		Languages:  []string{"Multiple"},
+		Extensions: []string{},
+	},
+}
 
 	// Build a list of tool language info for enabled tools
 	var configTools []domain.ToolLanguageInfo


### PR DESCRIPTION
# Config Discover Feature

## Overview
New `config discover` command that automatically detects programming languages in a project and configures appropriate static analysis tools.

## Usage
```bash
codacy-cli config discover <path>
```

## What it does
- Scans directory for file extensions
- Maps extensions to programming languages
- Updates `languages-config.yaml` and `codacy.yaml`
- Enables relevant tools (pylint, eslint, pmd, etc.)
- Creates tool-specific configuration files

## Key Changes
- **New**: `config/detector.go` - language detection logic
- **New**: `cmd/validation.go` - enhanced validation
- **Modified**: `cmd/config.go` - discover command implementation
- **Fixed**: Added missing `GetDefaultToolLanguageMapping()` function in `tools/language_config.go`

## Benefits
- Automatic project setup
- Reduces manual configuration
- Ensures comprehensive tool coverage
- Works in both local and cloud modes

## Example Output
```
Detected extensions: [.js, .py, .java]
Updated .codacy/tools-configs/languages-config.yaml
Updated codacy.yaml with relevant tools.
✅ Successfully discovered languages and updated configurations.
```
