### PR TITLE
Fix: CLI failes when running with non exsisting file  

### DIFF
--- a/cmd/analyze_test.go
+++ b/cmd/analyze_test.go
@@ -221,3 +221,44 @@ func TestEslintInstallationValidationLogic(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		paths       []string
+		expectError bool
+	}{
+		{
+			name:        "valid path",
+			paths:       []string{"."},
+			expectError: false,
+		},
+		{
+			name:        "non-existent file",
+			paths:       []string{"non-existent-file.txt"},
+			expectError: true,
+		},
+		{
+			name:        "multiple paths with one invalid",
+			paths:       []string{".", "non-existent-file.txt"},
+			expectError: true,
+		},
+		{
+			name:        "empty paths",
+			paths:       []string{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePaths(tt.paths)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "❌ Error: cannot find file or directory")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/integration-tests/init-with-token/expected/tools-configs/lizard.yaml
+++ b/integration-tests/init-with-token/expected/tools-configs/lizard.yaml
@@ -1,7 +1,7 @@
 patterns:
     Lizard_ccn-minor:
         category: Complexity
-        description: Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 5.
+        description: Checks that the cyclomatic complexity of functions or logic blocks does not exceed a minor threshold, defaulting to 5.
         explanation: |-
             # Minor Cyclomatic Complexity control
 
@@ -11,10 +11,10 @@ patterns:
         severityLevel: Info
         threshold: 5
         timeToFix: 5
-        title: Minor Cyclomatic Complexity control
+        title: Enforce Minor Cyclomatic Complexity Threshold
     Lizard_nloc-critical:
         category: Complexity
-        description: Check the number of lines of code (without comments) in a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 100.
+        description: Checks if functions or logic blocks exceed a set maximum number of lines of code (excluding comments), defaulting to 100 lines.
         explanation: |-
             # Critical NLOC control - Number of Lines of Code (without comments)
 
@@ -23,11 +23,11 @@ patterns:
         level: Error
         severityLevel: Error
         threshold: 100
-        timeToFix: 5
-        title: Critical NLOC control - Number of Lines of Code (without comments)
+        timeToFix: 15
+        title: Enforce Maximum Number of Lines of Code in Functions
     Lizard_nloc-medium:
         category: Complexity
-        description: Check the number of lines of code (without comments) in a function. If the threshold is not met, raise a Medium issue. The default threshold is 50.
+        description: Checks if the number of lines of code (excluding comments) in a function exceeds a medium threshold (default 50 lines).
         explanation: |-
             # Medium NLOC control - Number of Lines of Code (without comments)
 
@@ -36,5 +36,5 @@ patterns:
         level: Warning
         severityLevel: Warning
         threshold: 50
-        timeToFix: 5
-        title: Medium NLOC control - Number of Lines of Code (without comments)
+        timeToFix: 10
+        title: Enforce Medium Number of Lines of Code (NLOC) Limit

--- a/integration-tests/init-without-token/expected/tools-configs/lizard.yaml
+++ b/integration-tests/init-without-token/expected/tools-configs/lizard.yaml
@@ -10,7 +10,7 @@ patterns:
         level: Warning
         severityLevel: Warning
         threshold: 8
-        timeToFix: 5
+        timeToFix: 10
         title: Enforce Medium Cyclomatic Complexity Threshold
     Lizard_file-nloc-medium:
         category: Complexity
@@ -20,7 +20,7 @@ patterns:
         level: Warning
         severityLevel: Warning
         threshold: 500
-        timeToFix: 5
+        timeToFix: 10
         title: Enforce Medium File Length Limit Based on Number of Lines of Code
     Lizard_nloc-medium:
         category: Complexity
@@ -33,7 +33,7 @@ patterns:
         level: Warning
         severityLevel: Warning
         threshold: 50
-        timeToFix: 5
+        timeToFix: 10
         title: Enforce Medium Number of Lines of Code (NLOC) Limit
     Lizard_parameter-count-medium:
         category: Complexity
@@ -46,5 +46,5 @@ patterns:
         level: Warning
         severityLevel: Warning
         threshold: 8
-        timeToFix: 5
+        timeToFix: 10
         title: Enforce Medium Parameter Count Limit

--- a/plugins/tools/trivy/test/expected.sarif
+++ b/plugins/tools/trivy/test/expected.sarif
@@ -1,8 +1,69 @@
 {
-  "version": "2.1.0",
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "file:///plugins/tools/trivy/test/src/"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "message": {
+                "text": "package-lock.json: cross-spawn@7.0.3"
+              },
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "endColumn": 1,
+                  "endLine": 527,
+                  "startColumn": 1,
+                  "startLine": 515
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Package: cross-spawn\nInstalled Version: 7.0.3\nVulnerability CVE-2024-21538\nSeverity: HIGH\nFixed Version: 7.0.5, 6.0.6\nLink: [CVE-2024-21538](https://avd.aquasec.com/nvd/cve-2024-21538)"
+          },
+          "ruleId": "CVE-2024-21538",
+          "ruleIndex": 1
+        },
+        {
+          "level": "note",
+          "locations": [
+            {
+              "message": {
+                "text": "package-lock.json: brace-expansion@1.1.11"
+              },
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "endColumn": 1,
+                  "endLine": 357,
+                  "startColumn": 1,
+                  "startLine": 349
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Package: brace-expansion\nInstalled Version: 1.1.11\nVulnerability CVE-2025-5889\nSeverity: LOW\nFixed Version: 2.0.2, 1.1.12, 3.0.1, 4.0.1\nLink: [CVE-2025-5889](https://avd.aquasec.com/nvd/cve-2025-5889)"
+          },
+          "ruleId": "CVE-2025-5889",
+          "ruleIndex": 0
+        }
+      ],
       "tool": {
         "driver": {
           "fullName": "Trivy Vulnerability Scanner",
@@ -11,42 +72,8 @@
           "rules": null,
           "version": "0.59.1"
         }
-      },
-      "results": [
-        {
-          "ruleId": "CVE-2024-21538",
-          "ruleIndex": 0,
-          "level": "error",
-          "message": {
-            "text": "Package: cross-spawn\nInstalled Version: 7.0.3\nVulnerability CVE-2024-21538\nSeverity: HIGH\nFixed Version: 7.0.5, 6.0.6\nLink: [CVE-2024-21538](https://avd.aquasec.com/nvd/cve-2024-21538)"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "package-lock.json",
-                  "uriBaseId": "ROOTPATH"
-                },
-                "region": {
-                  "startLine": 515,
-                  "startColumn": 1,
-                  "endLine": 527,
-                  "endColumn": 1
-                }
-              },
-              "message": {
-                "text": "package-lock.json: cross-spawn@7.0.3"
-              }
-            }
-          ]
-        }
-      ],
-      "columnKind": "utf16CodeUnits",
-      "originalUriBaseIds": {
-        "ROOTPATH": {
-          "uri": "file:///plugins/tools/trivy/test/src/"
-        }
       }
     }
-  ]
+  ],
+  "version": "2.1.0"
 }


### PR DESCRIPTION
Now:
```
go run cli-v2.go  analyze --format sarif ./what
❌ Error: cannot find file or directory './what'
exit status 1
```

Before: 
```
2025/06/11 14:28:37 Failed to merge SARIF outputs: failed to parse SARIF file /tmp/codacy-analysis-2905944739/semgrep.sarif: unexpected end of JSON input
``` 

* this PR include it tests update 