### PR TITLE
Revert "hotfix: Disable file extensions check during analysis" CF-1680

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -476,12 +476,7 @@ Supports API token, provider, and repository flags to automatically fetch tool c
 		}
 
 		// Filter tools by language support
-		// HOT FIX - disable for now, file extensions are not considered during the analysis
-		// Need to support special `files` for languages like the ones defined here:
-		// https://github.com/codacy/codacy-plugins-api/blob/ed456e612382c688b6146f70ca0df6b4dfdf0bf9/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/languages/Language.scala#L102
-		//
-
-		// toolsToRun = FilterToolsByLanguageSupport(toolsToRun, args)
+		toolsToRun = FilterToolsByLanguageSupport(toolsToRun, args)
 
 		if len(toolsToRun) == 0 {
 			log.Println("No tools support the specified file(s). Skipping analysis.")


### PR DESCRIPTION
Reverts codacy/codacy-cli-v2#159 that start to analyze wrong files as we disabled the feature