### PR TITLE
feature: Upload sourceId when available from SARIF CF-1813

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"codacy/cli-v2/config"
 	"codacy/cli-v2/domain"
+	"codacy/cli-v2/plugins"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,11 +39,11 @@ var uploadResultsCmd = &cobra.Command{
 	Short: "Uploads a sarif file to Codacy",
 	Long:  "YADA",
 	Run: func(cmd *cobra.Command, args []string) {
-		processSarifAndSendResults(sarifPath, commitUuid, projectToken, apiToken)
+		processSarifAndSendResults(sarifPath, commitUuid, projectToken, apiToken, config.Config.Tools())
 	},
 }
 
-func processSarifAndSendResults(sarifPath string, commitUUID string, projectToken string, apiToken string) {
+func processSarifAndSendResults(sarifPath string, commitUUID string, projectToken string, apiToken string, tools map[string]*plugins.ToolInfo) {
 	if projectToken == "" && apiToken == "" && provider == "" && repository == "" {
 		fmt.Println("Error: api-token, provider and repository are required when project-token is not provided")
 		os.Exit(1)
@@ -64,7 +66,7 @@ func processSarifAndSendResults(sarifPath string, commitUUID string, projectToke
 	}
 
 	fmt.Println("Loading Codacy patterns...")
-	payloads := processSarif(sarif)
+	payloads := processSarif(sarif, tools)
 	if projectToken != "" {
 		for _, payload := range payloads {
 			sendResultsWithProjectToken(payload, commitUUID, projectToken)
@@ -80,7 +82,7 @@ func processSarifAndSendResults(sarifPath string, commitUUID string, projectToke
 
 }
 
-func processSarif(sarif Sarif) [][]map[string]interface{} {
+func processSarif(sarif Sarif, tools map[string]*plugins.ToolInfo) [][]map[string]interface{} {
 	var codacyIssues []map[string]interface{}
 	var payloads [][]map[string]interface{}
 
@@ -96,15 +98,21 @@ func processSarif(sarif Sarif) [][]map[string]interface{} {
 				continue
 			}
 			for _, location := range result.Locations {
-				codacyIssues = append(codacyIssues, map[string]interface{}{
+				issue := map[string]interface{}{
 					"source":   location.PhysicalLocation.ArtifactLocation.URI,
 					"line":     location.PhysicalLocation.Region.StartLine,
 					"type":     pattern.ID,
 					"message":  result.Message.Text,
 					"level":    pattern.Level,
 					"category": pattern.Category,
-					"sourceId": result.RuleID,
-				})
+				}
+
+				// Only add sourceId for tools that need it
+				if toolInfo, exists := tools[toolName]; exists && toolInfo.NeedsSourceIDUpload {
+					issue["sourceId"] = result.RuleID
+				}
+
+				codacyIssues = append(codacyIssues, issue)
 			}
 		}
 		var results []map[string]interface{}
@@ -134,7 +142,11 @@ func processSarif(sarif Sarif) [][]map[string]interface{} {
 						"line": obj["line"].(int),
 					},
 				},
-				"sourceId": obj["sourceId"].(string),
+			}
+
+			// Only add sourceId for tools that need it
+			if toolInfo, exists := tools[toolName]; exists && toolInfo.NeedsSourceIDUpload {
+				issue["sourceId"] = obj["sourceId"].(string)
 			}
 
 			// Check if we already have an entry for this filename

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -103,6 +103,7 @@ func processSarif(sarif Sarif) [][]map[string]interface{} {
 					"message":  result.Message.Text,
 					"level":    pattern.Level,
 					"category": pattern.Category,
+					"sourceId": result.RuleID,
 				})
 			}
 		}
@@ -133,6 +134,7 @@ func processSarif(sarif Sarif) [][]map[string]interface{} {
 						"line": obj["line"].(int),
 					},
 				},
+				"sourceId": obj["sourceId"].(string),
 			}
 
 			// Check if we already have an entry for this filename

--- a/plugins/tool-utils.go
+++ b/plugins/tool-utils.go
@@ -55,18 +55,19 @@ type RuntimeBinaries struct {
 
 // ToolPluginConfig holds the structure of the tool plugin.yaml file
 type ToolPluginConfig struct {
-	Name            string             `yaml:"name"`
-	Description     string             `yaml:"description"`
-	DefaultVersion  string             `yaml:"default_version"`
-	Runtime         string             `yaml:"runtime"`
-	RuntimeBinaries RuntimeBinaries    `yaml:"runtime_binaries"`
-	Installation    InstallationConfig `yaml:"installation"`
-	Download        DownloadConfig     `yaml:"download"`
-	Environment     map[string]string  `yaml:"environment"`
-	Binaries        []ToolBinary       `yaml:"binaries"`
-	Formatters      []Formatter        `yaml:"formatters"`
-	OutputOptions   OutputOptions      `yaml:"output_options"`
-	AnalysisOptions AnalysisOptions    `yaml:"analysis_options"`
+	Name                string             `yaml:"name"`
+	Description         string             `yaml:"description"`
+	DefaultVersion      string             `yaml:"default_version"`
+	Runtime             string             `yaml:"runtime"`
+	RuntimeBinaries     RuntimeBinaries    `yaml:"runtime_binaries"`
+	Installation        InstallationConfig `yaml:"installation"`
+	Download            DownloadConfig     `yaml:"download"`
+	Environment         map[string]string  `yaml:"environment"`
+	Binaries            []ToolBinary       `yaml:"binaries"`
+	Formatters          []Formatter        `yaml:"formatters"`
+	OutputOptions       OutputOptions      `yaml:"output_options"`
+	AnalysisOptions     AnalysisOptions    `yaml:"analysis_options"`
+	NeedsSourceIDUpload bool               `yaml:"needs_source_id_upload"`
 }
 
 // ToolConfig represents configuration for a tool
@@ -98,7 +99,8 @@ type ToolInfo struct {
 	FileName    string
 	Extension   string
 	// Environment variables
-	Environment map[string]string
+	Environment         map[string]string
+	NeedsSourceIDUpload bool
 }
 
 // ProcessTools processes a list of tool configurations and returns a map of tool information
@@ -151,7 +153,8 @@ func ProcessTools(configs []ToolConfig, toolDir string, runtimes map[string]*Run
 			InstallCommand:  pluginConfig.Installation.Command,
 			RegistryCommand: pluginConfig.Installation.RegistryTemplate,
 			// Store environment variables
-			Environment: make(map[string]string),
+			Environment:         make(map[string]string),
+			NeedsSourceIDUpload: pluginConfig.NeedsSourceIDUpload,
 		}
 
 		// Handle download configuration for directly downloaded tools

--- a/plugins/tool-utils_test.go
+++ b/plugins/tool-utils_test.go
@@ -66,6 +66,7 @@ func TestProcessTools(t *testing.T) {
 	// Assert installation command templates are correctly set
 	assert.Equal(t, "install --prefix {{.InstallDir}} {{.PackageName}}@{{.Version}} @microsoft/eslint-formatter-sarif", eslintInfo.InstallCommand)
 	assert.Equal(t, "config set registry {{.Registry}}", eslintInfo.RegistryCommand)
+	assert.Equal(t, eslintInfo.NeedsSourceIDUpload, false)
 }
 
 func TestProcessToolsWithDownload(t *testing.T) {
@@ -151,6 +152,7 @@ func TestProcessToolsWithDownload(t *testing.T) {
 		expectedArch = runtime.GOARCH
 	}
 	assert.Contains(t, trivyInfo.DownloadURL, expectedArch)
+	assert.Equal(t, trivyInfo.NeedsSourceIDUpload, true)
 }
 
 func TestGetSupportedTools(t *testing.T) {

--- a/plugins/tools/trivy/plugin.yaml
+++ b/plugins/tools/trivy/plugin.yaml
@@ -16,7 +16,7 @@ download:
     "darwin": "macOS"
     "linux": "Linux"
     "windows": "Windows"
-    
 binaries:
   - name: trivy
     path: "trivy"
+needs_source_id_upload: true


### PR DESCRIPTION
Only sending sourceId fror Trivy will avoid messing with the results from other tools and respects on how codacy cloud and the CLI v1 handles it.

The downside is that will be a bit error prone when adding other tools that 'need it' like Prospector, if forget to add it, less results will be added on Codacy, it will be kinda easy to identify, but can lead to that. For now it is an acceptable compromise.

- [x] Rely on the setting to actually upload or not the information

Note on diff coverage, changes on the upload.go not covered, and doing tests for the upload will not happen on this scope.